### PR TITLE
Update stats when delay is changed

### DIFF
--- a/ScreenToGif/Windows/Editor.xaml.cs
+++ b/ScreenToGif/Windows/Editor.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
@@ -4448,6 +4448,7 @@ namespace ScreenToGif.Windows
 
                 UpdateProgress(count++);
             }
+            UpdateStatistics();
         }
 
         private void DelayCallback(IAsyncResult ar)


### PR DESCRIPTION
For example:
1) Home->Select all frames
2) Edit->Override delay and enter 100ms
3) View Statistics tab
Expected: Total Duration and Average Duration should be updated.
Actual: Total Duration and Average Duration do not change

I expect it just needs a call to UpdateStatistics() ?