### PR TITLE
Units for Total Duration

### DIFF
--- a/ScreenToGif/Windows/Editor.xaml
+++ b/ScreenToGif/Windows/Editor.xaml
@@ -1160,7 +1160,7 @@
 
                         <Viewbox Grid.Row="2" Grid.Column="0" Child="{StaticResource Vector.Clock}" Height="18" Width="18" VerticalAlignment="Center"/>
                         <TextBlock Grid.Row="2" Grid.Column="1" Text="{DynamicResource Editor.Statistics.TotalDuration}" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="5,0" Foreground="Black"/>
-                        <TextBlock Grid.Row="3" Grid.Column="1" Text="{Binding ElementName=EditorWindow, Path=TotalDuration, StringFormat='{}{0:mm\\:ss\\.fff} m'}" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                        <TextBlock Grid.Row="3" Grid.Column="1" Text="{Binding ElementName=EditorWindow, Path=TotalDuration, StringFormat='{}{0:mm\\:ss\\.fff}'}" HorizontalAlignment="Center" VerticalAlignment="Center"/>
 
                         <Viewbox Grid.Row="0" Grid.Column="3" Child="{StaticResource Vector.WidthHeight}" Height="18" Width="18" VerticalAlignment="Center"/>
                         <TextBlock Grid.Row="0" Grid.Column="4" Text="{DynamicResource Editor.Statistics.FrameSize}" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="5,0" Foreground="Black"/>


### PR DESCRIPTION
I'm not sure that a unit is needed here ("m" for "minutes"). It confused me a bit when I made a short screen recording and it said "Total Duration 0:00:12.345 m" and I thought "there is no way that recording is 12.345 minutes long".
Actually, because the first field is the hours (even though hard-coded to zero) there is some argument that the units are "hr". And the last part is seconds, so the unit could be "sec".
So I think best to not mention any unit of measure.