### PR TITLE
Improve wording of OverrideDelay IncreaseDecreaseDelay text

### DIFF
--- a/ScreenToGif/Resources/Localization/StringResources.en.xaml
+++ b/ScreenToGif/Resources/Localization/StringResources.en.xaml
@@ -565,8 +565,8 @@
     <s:String x:Key="Delay.DecreaseIncrease">Decrease/Increase Value</s:String>
     
     <s:String x:Key="Cinemagraph.Info">Use the pen to select the pixels that should not remain static (that should change among frames), by painting on top of them.</s:String>
-    <s:String x:Key="OverrideDelay.Info">This new value will replace the duration (delay) of all selected frames. The value should stay between 10ms and 25.500ms.</s:String>
-    <s:String x:Key="IncreaseDecreaseDelay.Info">This value will decrease/increase the duration (delay) of each selected frame.&#x0d;You can increment/decrement by selecting a value between -10.000ms and 10.000ms, but the duration of each frame will range between 10ms and 25.500ms</s:String>
+    <s:String x:Key="OverrideDelay.Info">This new value will replace the duration (delay) of all selected frames. The value can be from 10ms to 25500ms.</s:String>
+    <s:String x:Key="IncreaseDecreaseDelay.Info">This value will decrease/increase the duration (delay) of each selected frame.&#x0d;You can decrement/increment by selecting a value between -10000ms and 10000ms, but the final duration of each frame will be restricted to between 10ms and 25500ms</s:String>
     
     <s:String x:Key="Transitions.Lenght">Transition Length</s:String>
     <s:String x:Key="Transitions.FadeTo">Fade To...</s:String>


### PR DESCRIPTION
The use of the decimal point here (like 10.000ms) is confusing, because in European style this means 10 thousand but in US/UK style it means exactly 10 milliseconds and "000" microseconds. I guess there might be some way to localize that so that the digits separator from the locale is automagically used?
This is a suggested way to reword it, and write out the milliseconds numbers without any "." or "," separator.