### PR TITLE
Update URL of the English reference file

### DIFF
--- a/ScreenToGif/Windows/Options.xaml.cs
+++ b/ScreenToGif/Windows/Options.xaml.cs
@@ -654,7 +654,7 @@ namespace ScreenToGif.Windows
         {
             try
             {
-                Process.Start("http://screentogif.codeplex.com/SourceControl/latest#ScreenToGif/Resources/Localization/StringResources.en.xaml");
+                Process.Start("https://github.com/NickeManarin/ScreenToGif/raw/master/ScreenToGif/Resources/Localization/StringResources.en.xaml");
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
It seems that the `StringResources.en.xaml` file on CodePlex is older that the one on GitHub: shall we use the latter?