### PR TITLE
WatermarkLeft and WatermarkTop are now properly saved to config file.

### DIFF
--- a/ScreenToGif/Util/UserSettings.cs
+++ b/ScreenToGif/Util/UserSettings.cs
@@ -1133,15 +1133,15 @@ namespace ScreenToGif.Util
             set => SetValue(value);
         }
 
-        public double WatermarkTop
+        public int WatermarkTop
         {
-            get => (double)GetValue();
+            get => Convert.ToInt32(GetValue());
             set => SetValue(value);
         }
 
-        public double WatermarkLeft
+        public int WatermarkLeft
         {
-            get => (double)GetValue();
+            get => Convert.ToInt32(GetValue());
             set => SetValue(value);
         }
 


### PR DESCRIPTION
There was double used but integer control operated only on ints.
Issue: #170 

Works properly with older config files.