### PR TITLE
Correctly open target directory from encoder window

### DIFF
--- a/ScreenToGif/Controls/EncoderListViewItem.cs
+++ b/ScreenToGif/Controls/EncoderListViewItem.cs
@@ -346,7 +346,7 @@ namespace ScreenToGif.Controls
                     try
                     {
                         if (!string.IsNullOrWhiteSpace(OutputFilename) && Directory.Exists(OutputPath))
-                            Process.Start("explorer.exe", $"/select,\"{OutputFilename}\"");
+                            Process.Start("explorer.exe", $"{OutputFilename}");
                     }
                     catch (Exception ex)
                     {


### PR DESCRIPTION
Currently, when clicking on the "Explore Folder" button in the Encoder Window takes you to "This PC", this tweak seeks to correct that behaviour by opening an explorer window in the path of the saved file.