### PR TITLE
Sanitise OutputFilename before attempting to open explorer 

### DIFF
--- a/ScreenToGif/Controls/EncoderListViewItem.cs
+++ b/ScreenToGif/Controls/EncoderListViewItem.cs
@@ -346,7 +346,7 @@ namespace ScreenToGif.Controls
                     try
                     {
                         if (!string.IsNullOrWhiteSpace(OutputFilename) && Directory.Exists(OutputPath))
-                            Process.Start("explorer.exe", $"/select,\"{OutputFilename}\"");
+                            Process.Start("explorer.exe", $"/select,\"{OutputFilename.Replace("/","\\")}\"");
                     }
                     catch (Exception ex)
                     {


### PR DESCRIPTION
(Redo of previous #197)

Noticed `OutputFilename` was populated wrongly (perhaps):
![image](https://user-images.githubusercontent.com/1998970/31866702-7483808e-b77b-11e7-8c7e-f3931ebb9a60.png)

This is a quick fix to ensure that explorer will open in the right place.
![fixed](https://user-images.githubusercontent.com/1998970/31866708-8faff4f0-b77b-11e7-9314-313b523db4d4.gif)

Bonus: Here is the project file for the gif above
[project.zip](https://github.com/NickeManarin/ScreenToGif/files/1405381/project.zip)

