### PR TITLE
Fix V3083 warnings from PVS-Studio Static Analyzer

### DIFF
--- a/GifRecorder/Util/UserActivityHook.cs
+++ b/GifRecorder/Util/UserActivityHook.cs
@@ -709,7 +709,7 @@ namespace ScreenToGif.Util
                                             mouseHookStruct.pt.y,
                                             mouseDelta);
                 //Raise it
-                OnMouseActivity(this, e);
+                OnMouseActivity?.Invoke(this, e);
             }
             
             //call next hook
@@ -757,7 +757,7 @@ namespace ScreenToGif.Util
 
                     var keyData = (Keys)myKeyboardHookStruct.vkCode;
                     var e = new KeyEventArgs(keyData);
-                    KeyDown(this, e);
+                    KeyDown?.Invoke(this, e);
                     handled = handled || e.Handled;
 
                     #endregion
@@ -780,7 +780,7 @@ namespace ScreenToGif.Util
                         if ((isDownCapslock ^ isDownShift) && Char.IsLetter(key)) 
                             key = Char.ToUpper(key);
                         var e = new KeyPressEventArgs(key);
-                        KeyPress(this, e);
+                        KeyPress?.Invoke(this, e);
                         handled = handled || e.Handled;
                     }
 
@@ -793,7 +793,7 @@ namespace ScreenToGif.Util
 
                     var keyData = (Keys)myKeyboardHookStruct.vkCode;
                     var e = new KeyEventArgs(keyData);
-                    KeyUp(this, e);
+                    KeyUp?.Invoke(this, e);
                     handled = handled || e.Handled;
 
                     #endregion

--- a/Other/HookTest/Util/UserActivityHook.cs
+++ b/Other/HookTest/Util/UserActivityHook.cs
@@ -765,7 +765,7 @@ namespace HookTest.Util
                 var e = new CustomMouseEventArgs(button, clickCount, mouseHookStruct.pt.x, mouseHookStruct.pt.y, mouseDelta);
                 
                 //Raise it
-                OnMouseActivity(this, e);
+                OnMouseActivity?.Invoke(this, e);
             }
             
             //Call next hook
@@ -813,7 +813,7 @@ namespace HookTest.Util
 
                     var keyData = (Keys)myKeyboardHookStruct.vkCode;
                     var e = new CustomKeyEventArgs(keyData);
-                    KeyDown(this, e);
+                    KeyDown?.Invoke(this, e);
                     
                     handled = handled || e.Handled;
 
@@ -838,7 +838,7 @@ namespace HookTest.Util
                             key = Char.ToUpper(key);
                         
                         var e = new CustomKeyPressEventArgs(key);
-                        KeyPress(this, e);
+                        KeyPress?.Invoke(this, e);
 
                         handled = handled || e.Handled;
                     }
@@ -852,7 +852,7 @@ namespace HookTest.Util
 
                     var keyData = (Keys)myKeyboardHookStruct.vkCode;
                     var e = new CustomKeyEventArgs(keyData);
-                    KeyUp(this, e);
+                    KeyUp?.Invoke(this, e);
 
                     handled = handled || e.Handled;
 

--- a/ScreenToGif/Controls/ImageScrollViewer.cs
+++ b/ScreenToGif/Controls/ImageScrollViewer.cs
@@ -66,8 +66,7 @@ namespace ScreenToGif.Controls
                     _scaleTransform.ScaleY = Zoom;
                 }
 
-                if (ZoomChanged != null)
-                    ZoomChanged(this, new EventArgs());
+                ZoomChanged?.Invoke(this, new EventArgs());
             }
         }
 

--- a/ScreenToGif/Controls/SpectrumSlider.cs
+++ b/ScreenToGif/Controls/SpectrumSlider.cs
@@ -77,10 +77,7 @@ namespace ScreenToGif.Controls
 
         void _colorThumb_MouseLeftButtonUp(object sender, MouseButtonEventArgs e)
         {
-            if (AfterSelecting != null)
-            {
-                AfterSelecting();
-            }
+            AfterSelecting?.Invoke();
         }
 
         private void _colorThumb_MouseEnter(object sender, MouseEventArgs e)

--- a/ScreenToGif/Util/ActivityHook/UserActivityHook.cs
+++ b/ScreenToGif/Util/ActivityHook/UserActivityHook.cs
@@ -825,7 +825,7 @@ namespace ScreenToGif.Util.ActivityHook
 
                 var e = new CustomKeyEventArgs(KeyInterop.KeyFromVirtualKey(myKeyboardHookStruct.vkCode));
 
-                KeyUp(this, e);
+                KeyUp?.Invoke(this, e);
 
                 handled = handled || e.Handled;
 

--- a/ScreenToGif/Webcam/DirectX/CaptureWebcam.cs
+++ b/ScreenToGif/Webcam/DirectX/CaptureWebcam.cs
@@ -619,7 +619,7 @@ namespace ScreenToGif.Webcam.DirectX
             var b = new Bitmap(width, height, -stride, System.Drawing.Imaging.PixelFormat.Format24bppRgb, (IntPtr)scan0);
             handle.Free();
 
-            CaptureFrameEvent(b);
+            CaptureFrameEvent?.Invoke(b);
 
             return 0;
         }


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug found using PVS-Studio. Warnings:

- [V3083 ](https://www.viva64.com/en/w/v3083/)Unsafe invocation of event 'ZoomChanged', NullReferenceException is possible. Consider assigning event to a local variable before invoking it. ImageScrollViewer.cs 70
- [V3083 ](https://www.viva64.com/en/w/v3083/)Unsafe invocation of event 'AfterSelecting', NullReferenceException is possible. Consider assigning event to a local variable before invoking it. SpectrumSlider.cs 82
- [V3083 ](https://www.viva64.com/en/w/v3083/)Unsafe invocation of event 'KeyUp', NullReferenceException is possible. Consider assigning event to a local variable before invoking it. UserActivityHook.cs 828
- [V3083 ](https://www.viva64.com/en/w/v3083/)Unsafe invocation of event 'CaptureFrameEvent', NullReferenceException is possible. Consider assigning event to a local variable before invoking it. CaptureWebcam.cs 622
- [V3083 ](https://www.viva64.com/en/w/v3083/)Unsafe invocation of event 'OnMouseActivity', NullReferenceException is possible. Consider assigning event to a local variable before invoking it. UserActivityHook.cs 712
- [V3083 ](https://www.viva64.com/en/w/v3083/)Unsafe invocation of event 'KeyDown', NullReferenceException is possible. Consider assigning event to a local variable before invoking it. UserActivityHook.cs 760
- [V3083 ](https://www.viva64.com/en/w/v3083/)Unsafe invocation of event 'KeyPress', NullReferenceException is possible. Consider assigning event to a local variable before invoking it. UserActivityHook.cs 783
- [V3083 ](https://www.viva64.com/en/w/v3083/)Unsafe invocation of event 'KeyUp', NullReferenceException is possible. Consider assigning event to a local variable before invoking it. UserActivityHook.cs 796
- [V3083 ](https://www.viva64.com/en/w/v3083/)Unsafe invocation of event 'OnMouseActivity', NullReferenceException is possible. Consider assigning event to a local variable before invoking it. UserActivityHook.cs 768
- [V3083 ](https://www.viva64.com/en/w/v3083/)Unsafe invocation of event 'KeyDown', NullReferenceException is possible. Consider assigning event to a local variable before invoking it. UserActivityHook.cs 816
- [V3083 ](https://www.viva64.com/en/w/v3083/)Unsafe invocation of event 'KeyPress', NullReferenceException is possible. Consider assigning event to a local variable before invoking it. UserActivityHook.cs 841
- [V3083 ](https://www.viva64.com/en/w/v3083/)Unsafe invocation of event 'KeyUp', NullReferenceException is possible. Consider assigning event to a local variable before invoking it. UserActivityHook.cs 855