### PR TITLE
Small fixes for localization

### DIFF
--- a/Other/Translator/TranslatorWindow.xaml.cs
+++ b/Other/Translator/TranslatorWindow.xaml.cs
@@ -243,27 +243,22 @@ namespace Translator
             }
             catch(CultureNotFoundException)
             {
-                Dispatcher.Invoke(() => Dialog.Ok("Action Denied", "Unknown Language.", $"The \"{specificCulture}\" and its family were not recognized as a valid language codes."));
+                Dialog.Ok("Action Denied", "Unknown Language.", 
+                    $"The \"{specificCulture}\" and its family were not recognized as a valid language codes.");
 
                 return;
             }
             catch(Exception ex)
             {
-                Dispatcher.Invoke(() => Dialog.Ok("Action Denied", "Error checking culture.", ex.Message));
-
-                return;
-            }
-
-            if (properCulture == null)
-            {
-                Dispatcher.Invoke(() => Dialog.Ok("Action Denied", "Unknown Language.", $"The \"{specificCulture}\" and its family were not recognized as a valid language codes."));
+                Dialog.Ok("Action Denied", "Error checking culture.", ex.Message);
 
                 return;
             }
 
             if (properCulture.Name != specificCulture)
             {
-                Dispatcher.Invoke(() => Dialog.Ok("Action Denied", "Redundant Language Code.", $"The \"{specificCulture}\" code is redundant. Try using \'{properCulture.Name}\" instead"));
+                Dialog.Ok("Action Denied", "Redundant Language Code.", 
+                    $"The \"{specificCulture}\" code is redundant. Try using \'{properCulture.Name}\" instead");
 
                 return;
             }
@@ -624,9 +619,6 @@ namespace Translator
 
         private CultureInfo CheckSupportedCulture(CultureInfo culture)
         {
-            if (culture == null)
-                return null;
-
             if (_cultureList.Contains(culture))
                 return culture;
 

--- a/ScreenToGif/Util/LocalizationHelper.cs
+++ b/ScreenToGif/Util/LocalizationHelper.cs
@@ -145,6 +145,7 @@ namespace ScreenToGif.Util
             catch(Exception ex)
             {
                 LogWriter.Log(ex, "Import Resource");
+                //Rethrowing, because it's more useful to catch later
                 throw;
             }
         }
@@ -200,6 +201,7 @@ namespace ScreenToGif.Util
             catch(Exception ex)
             {
                 LogWriter.Log(ex, "Save Resource", selectedIndex);
+                //Rethrowing, because it's more useful to catch later
                 throw;
             }
         }

--- a/ScreenToGif/Util/LocalizationHelper.cs
+++ b/ScreenToGif/Util/LocalizationHelper.cs
@@ -180,22 +180,14 @@ namespace ScreenToGif.Util
 
     public static void SaveSelected(int selectedIndex, string path)
     {
-        try
-        {
-            if (selectedIndex < 0 || selectedIndex > Application.Current.Resources.MergedDictionaries.Count - 1)
-                throw new IndexOutOfRangeException("Index out of range while trying to save the resource dictionary.");
+         if (selectedIndex < 0 || selectedIndex > Application.Current.Resources.MergedDictionaries.Count - 1)
+             throw new IndexOutOfRangeException("Index out of range while trying to save the resource dictionary.");
 
-            var settings = new XmlWriterSettings { Indent = true };
+         var settings = new XmlWriterSettings { Indent = true };
 
-            using (var writer = XmlWriter.Create(path, settings))
-                System.Windows.Markup.XamlWriter.Save(Application.Current.Resources.MergedDictionaries[selectedIndex], writer);
-        }
-        catch (Exception ex)
-        {
-            LogWriter.Log(ex, "Save Xaml Resource Error");
+         using (var writer = XmlWriter.Create(path, settings))
+             System.Windows.Markup.XamlWriter.Save(Application.Current.Resources.MergedDictionaries[selectedIndex], writer);
 
-            Dialog.Ok("Impossible to Save", "Impossible to save the Xaml file", ex.Message, Dialog.Icons.Warning);
-        }
     }
 
     public static bool Remove(int selectedIndex)

--- a/ScreenToGif/Util/LocalizationHelper.cs
+++ b/ScreenToGif/Util/LocalizationHelper.cs
@@ -5,7 +5,6 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Threading;
-using System.Threading.Tasks;
 using System.Windows;
 using System.Xml;
 
@@ -125,91 +124,106 @@ namespace ScreenToGif.Util
 
         public static void ImportStringResource(string path)
         {
-            if (string.IsNullOrEmpty(path))
-                throw new ArgumentException("Path is null");
-
-            using (var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read))
+            try
             {
-                if (fs.Length == 0)
-                    throw new InvalidDataException("File is empty");
+                if (string.IsNullOrEmpty(path))
+                    throw new ArgumentException("Path is null");
 
-                //Reads the ResourceDictionary file
-                var dictionary = (ResourceDictionary)System.Windows.Markup.XamlReader.Load(fs);
-                dictionary.Source = new Uri(path);
+                using (var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read))
+                {
+                    if (fs.Length == 0)
+                        throw new InvalidDataException("File is empty");
 
-                //Add in newly loaded Resource Dictionary.
-                Application.Current.Resources.MergedDictionaries.Add(dictionary);
+                    //Reads the ResourceDictionary file
+                    var dictionary = (ResourceDictionary)System.Windows.Markup.XamlReader.Load(fs);
+                    dictionary.Source = new Uri(path);
+
+                    //Add in newly loaded Resource Dictionary.
+                    Application.Current.Resources.MergedDictionaries.Add(dictionary);
+                }
+            }
+            catch(Exception ex)
+            {
+                LogWriter.Log(ex, "Import Resource");
+                throw;
             }
         }
 
-    public static List<ResourceDictionary> GetLocalizations()
-    {
-        //Copy all MergedDictionarys into a auxiliar list.
-        var dictionaryList = Application.Current.Resources.MergedDictionaries.ToList();
-
-        return dictionaryList.Where(x => x.Source.OriginalString.Contains("StringResource")).ToList();
-    }
-
-    public static bool Move(int selectedIndex, bool toUp = true)
-    {
-        try
+        public static List<ResourceDictionary> GetLocalizations()
         {
-            if (toUp && selectedIndex < 1)
-                return false;
+            //Copy all MergedDictionarys into a auxiliar list.
+            var dictionaryList = Application.Current.Resources.MergedDictionaries.ToList();
 
-            if (!toUp && selectedIndex > Application.Current.Resources.MergedDictionaries.Count - 1)
-                return false;
-
-            //Recover selected dictionary.
-            var dictionaryAux = Application.Current.Resources.MergedDictionaries[selectedIndex];
-
-            //Remove from the current list.
-            Application.Current.Resources.MergedDictionaries.Remove(Application.Current.Resources.MergedDictionaries[selectedIndex]);
-
-            //Insert at the upper position.
-            Application.Current.Resources.MergedDictionaries.Insert(toUp ? selectedIndex - 1 : selectedIndex + 1, dictionaryAux);
-
-            return true;
+            return dictionaryList.Where(x => x.Source.OriginalString.Contains("StringResource")).ToList();
         }
-        catch (Exception ex)
+
+        public static bool Move(int selectedIndex, bool toUp = true)
         {
-            LogWriter.Log(ex, "Move Resource", selectedIndex);
-            return false;
+            try
+            {
+                if (toUp && selectedIndex < 1)
+                    return false;
+
+                if (!toUp && selectedIndex > Application.Current.Resources.MergedDictionaries.Count - 1)
+                    return false;
+
+                //Recover selected dictionary.
+                var dictionaryAux = Application.Current.Resources.MergedDictionaries[selectedIndex];
+
+                //Remove from the current list.
+                Application.Current.Resources.MergedDictionaries.Remove(Application.Current.Resources.MergedDictionaries[selectedIndex]);
+
+                //Insert at the upper position.
+                Application.Current.Resources.MergedDictionaries.Insert(toUp ? selectedIndex - 1 : selectedIndex + 1, dictionaryAux);
+
+                return true;
+            }
+            catch (Exception ex)
+            {
+                LogWriter.Log(ex, "Move Resource", selectedIndex);
+                return false;
+            }
+        }
+
+        public static void SaveSelected(int selectedIndex, string path)
+        {
+            try
+            {
+                if (selectedIndex < 0 || selectedIndex > Application.Current.Resources.MergedDictionaries.Count - 1)
+                    throw new IndexOutOfRangeException("Index out of range while trying to save the resource dictionary.");
+
+                var settings = new XmlWriterSettings { Indent = true };
+
+                using (var writer = XmlWriter.Create(path, settings))
+                    System.Windows.Markup.XamlWriter.Save(Application.Current.Resources.MergedDictionaries[selectedIndex], writer);
+            }
+            catch(Exception ex)
+            {
+                LogWriter.Log(ex, "Save Resource", selectedIndex);
+                throw;
+            }
+        }
+
+        public static bool Remove(int selectedIndex)
+        {
+            try
+            {
+                if (selectedIndex == -1 || selectedIndex > Application.Current.Resources.MergedDictionaries.Count - 1)
+                    return false;
+
+                if (Application.Current.Resources.MergedDictionaries[selectedIndex].Source.OriginalString.Contains("StringResources.xaml"))
+                    return false;
+
+                //Remove from the current list.
+                Application.Current.Resources.MergedDictionaries.RemoveAt(selectedIndex);
+
+                return true;
+            }
+            catch (Exception ex)
+            {
+                LogWriter.Log(ex, "Remove Resource", selectedIndex);
+                return false;
+            }
         }
     }
-
-    public static void SaveSelected(int selectedIndex, string path)
-    {
-         if (selectedIndex < 0 || selectedIndex > Application.Current.Resources.MergedDictionaries.Count - 1)
-             throw new IndexOutOfRangeException("Index out of range while trying to save the resource dictionary.");
-
-         var settings = new XmlWriterSettings { Indent = true };
-
-         using (var writer = XmlWriter.Create(path, settings))
-             System.Windows.Markup.XamlWriter.Save(Application.Current.Resources.MergedDictionaries[selectedIndex], writer);
-
-    }
-
-    public static bool Remove(int selectedIndex)
-    {
-        try
-        {
-            if (selectedIndex == -1 || selectedIndex > Application.Current.Resources.MergedDictionaries.Count - 1)
-                return false;
-
-            if (Application.Current.Resources.MergedDictionaries[selectedIndex].Source.OriginalString.Contains("StringResources.xaml"))
-                return false;
-
-            //Remove from the current list.
-            Application.Current.Resources.MergedDictionaries.RemoveAt(selectedIndex);
-
-            return true;
-        }
-        catch (Exception ex)
-        {
-            LogWriter.Log(ex, "Remove Resource", selectedIndex);
-            return false;
-        }
-    }
-}
 }

--- a/ScreenToGif/Windows/Other/Localization.xaml
+++ b/ScreenToGif/Windows/Other/Localization.xaml
@@ -26,6 +26,8 @@
             <RowDefinition/>
             <RowDefinition Height="40"/>
         </Grid.RowDefinitions>
+        
+        <c:StatusBand Grid.Row="0" x:Name="StatusBand"/>
 
         <Grid Grid.Row="1">
             <Grid.RowDefinitions>

--- a/ScreenToGif/Windows/Other/Localization.xaml.cs
+++ b/ScreenToGif/Windows/Other/Localization.xaml.cs
@@ -34,6 +34,11 @@ namespace ScreenToGif.Windows.Other
             StatusBand.Info("Getting resources...");
 
             AddButton.IsEnabled = false;
+            SaveButton.IsEnabled = false;
+            RemoveButton.IsEnabled = false;
+            DownButton.IsEnabled = false;
+            UpButton.IsEnabled = false;
+            OkButton.IsEnabled = false;
 
             foreach (var resourceDictionary in Application.Current.Resources.MergedDictionaries)
             {
@@ -81,6 +86,12 @@ namespace ScreenToGif.Windows.Other
 
             ResourceListBox.SelectedIndex = ResourceListBox.Items.Count - 1;
             ResourceListBox.ScrollIntoView(ResourceListBox.SelectedItem);
+
+            SaveButton.IsEnabled = true;
+            RemoveButton.IsEnabled = true;
+            DownButton.IsEnabled = true;
+            UpButton.IsEnabled = true;
+            OkButton.IsEnabled = true;
 
             StatusBand.Info("Getting language codes...");
 

--- a/ScreenToGif/Windows/Other/Localization.xaml.cs
+++ b/ScreenToGif/Windows/Other/Localization.xaml.cs
@@ -20,7 +20,7 @@ namespace ScreenToGif.Windows.Other
 {
     public partial class Localization : Window
     {
-        private IEnumerable<string> _cultureList;
+        private IEnumerable<string> _cultures;
 
         public Localization()
         {
@@ -95,7 +95,7 @@ namespace ScreenToGif.Windows.Other
 
             StatusBand.Info("Getting language codes...");
 
-            _cultureList = await GetProperCulturesAsync();
+            _cultures = await GetProperCulturesAsync();
 
             StatusBand.Hide();
             AddButton.IsEnabled = true;
@@ -178,13 +178,15 @@ namespace ScreenToGif.Windows.Other
             sfd.FileName = subs;
 
             var result = sfd.ShowDialog();
-            int index = ResourceListBox.SelectedIndex;
+            var fileName = sfd.FileName;
+            //We have to access UI components here (can't do that in the task below)
+            var index = ResourceListBox.SelectedIndex;
 
             if (result.HasValue && result.Value)
             {
                 try
                 {
-                    await Task.Factory.StartNew(() => LocalizationHelper.SaveSelected(index, sfd.FileName));
+                    await Task.Factory.StartNew(() => LocalizationHelper.SaveSelected(index, fileName));
                 }
                 catch (Exception ex)
                 {
@@ -327,7 +329,10 @@ namespace ScreenToGif.Windows.Other
 
         private string CheckSupportedCulture(string cultureName)
         {
-            HashSet<string> cultureHash = new HashSet<string>(_cultureList);
+            //Using HashSet, because we can check if it contains string in O(1) time
+            //Only creating it takes some time,
+            //but it's better than performing Contains multiple times on the list in the loop below
+            HashSet<string> cultureHash = new HashSet<string>(_cultures);
 
             if (cultureHash.Contains(cultureName))
                 return cultureName;

--- a/ScreenToGif/Windows/Other/Localization.xaml.cs
+++ b/ScreenToGif/Windows/Other/Localization.xaml.cs
@@ -288,9 +288,11 @@ namespace ScreenToGif.Windows.Other
 
             StatusBand.Info("Importing resource...");
 
+            var fileName = ofd.FileName;
+
             try
             {
-                await Task.Factory.StartNew(() => LocalizationHelper.ImportStringResource(ofd.FileName));
+                await Task.Factory.StartNew(() => LocalizationHelper.ImportStringResource(fileName));
             }
             catch(Exception ex)
             {


### PR DESCRIPTION
Fixed mistakes from #269 and slightly changed existing code

- Removed unnecessary calls to Dispatcher
- Now language codes are stored in a variable (so we don't have to download them again in Localization window after clicking Add button)
- In Translation window, the English language is downloaded at the start. It's necessary if someone wants to import resource first without refreshing
- Added status band in Localization window
- Made code more asynchronous when it was possible
- Other minor cosmetic changes