### PR TITLE
Fix status control position on multi-monitor system

### DIFF
--- a/ScreenToGif/Controls/SelectControl.cs
+++ b/ScreenToGif/Controls/SelectControl.cs
@@ -480,7 +480,16 @@ namespace ScreenToGif.Controls
             if (!point.HasValue)
                 return;
 
-            var monitor = Monitors.FirstOrDefault(x => x.Bounds.Contains(point.Value));
+            //If the main monitor is not the most left / top one, the bounds of monitors left to / above the main monitor are negative,
+            //But the cursor point is always starting from 0,0
+            //So, the cursor point may not fall into any monitor bounds (exceed the maximum right / bottom coordinate)
+            //As a result, convert the cursor point into the same axis of monitors by plusing the negative left / top coordinate
+            double minimumMonitorTop = Monitors.Min(x => x.Bounds.Top);
+            double minimumMonitorLeft = Monitors.Min(x => x.Bounds.Left);
+
+            Point absolutePoint = new Point(point.Value.X + minimumMonitorLeft, point.Value.Y + minimumMonitorTop);
+
+            var monitor = Monitors.FirstOrDefault(x => x.Bounds.Contains(absolutePoint));
 
             if (monitor == null)
                 return;


### PR DESCRIPTION
This should fix #342 .

When multiple monitors are connected and the main monitor is not the most top / left one, the monitors whose position are even left / above the main monitor may have a negative coordinate as boundary.
However, the current cursor point is always starting from the most top / left corner as 0, 0, no negative value is obtained.

So, when you really draw something on the main monitor, the current cursor point may exceed the boundaries of all the monitors, and as a result, no status control toolbar is displayed.

This commit recalculates the current cursor point by taking the negative coordinate into consideration, to make sure it falls into the proper monitor.