### PR TITLE
Stop countdown timer for new recorder UI

### DIFF
--- a/ScreenToGif/Windows/Other/RecorderNew.xaml.cs
+++ b/ScreenToGif/Windows/Other/RecorderNew.xaml.cs
@@ -865,6 +865,12 @@ namespace ScreenToGif.Windows.Other
                 {
                     #region if Pre-Starting or in Snapmode and no Frames, Stops
 
+                    if (Stage == Stage.PreStarting)
+                    {
+                        //Stop the pre-start timer to kill pre-start warming up
+                        _preStartTimer.Stop();
+                    }
+
                     //Only returns to the stopped stage if it was recording.
                     Stage = Stage == Stage.Snapping ? Stage.Snapping : Stage.Stopped;
 


### PR DESCRIPTION
When Pre-Start is in use and a countdown is running, pressing Stop button doesn't really stop the countdown, and the capture still starts after the countdown ends.

This commit should fix #344 

Unfortunately I didn't have enough time to go over all modes, but at least for me, New Recorder UI works fine after this change.