### PR TITLE
LastSelected need clear when new project loaded

### DIFF
--- a/ScreenToGif/Windows/Editor.xaml.cs
+++ b/ScreenToGif/Windows/Editor.xaml.cs
@@ -3488,7 +3488,7 @@ namespace ScreenToGif.Windows
         {
             Cursor = Cursors.AppStarting;
             IsLoading = true;
-
+            LastSelected = -1;  //lastSelected need clear when new porject loaded
             FrameListView.Items.Clear();
             ZoomBoxControl.Zoom = 1;
 


### PR DESCRIPTION
LastSelected  need clear when new project load,Otherwise will raise index exceed frames length error when you previous project LastSelected  number is larger than new project frames number.