### PR TITLE
Defaults to "Ctrl"

### DIFF
--- a/ScreenToGif/Util/Native.cs
+++ b/ScreenToGif/Util/Native.cs
@@ -1988,7 +1988,19 @@ namespace ScreenToGif.Util
                 return "";
 
             //Get the modifers as text.
-            var modifiersText = Enum.GetValues(modifier.GetType()).OfType<Enum>().Where(x => (ModifierKeys)x != ModifierKeys.None && modifier.HasFlag(x)).Aggregate("", (current, mod) => current + (mod + " + "));
+            var modifiersText = Enum.GetValues(modifier.GetType()).OfType<ModifierKeys>()
+                .Where(x => x != ModifierKeys.None && modifier.HasFlag(x))
+                .Aggregate("", (current, mod) =>
+                {
+                    if (mod == ModifierKeys.Control)
+                    {
+                        return current + "Ctrl" + " + ";
+                    }
+                    else
+                    {
+                        return current + mod + " + ";
+                    }
+                });
 
             var result = GetCharFromKey(key);
 
@@ -2001,7 +2013,7 @@ namespace ScreenToGif.Util
                 {
                     case Key.LeftCtrl:
                     case Key.RightCtrl:
-                        keyText = "Control";
+                        keyText = "Ctrl";
                         break;
                     case Key.LeftShift:
                     case Key.RightShift:
@@ -2066,6 +2078,10 @@ namespace ScreenToGif.Util
                 #endregion
             }
 
+            if (modifiersText.Length > 0)
+            {
+                isUppercase = true;
+            }
             return modifiersText + (isUppercase ? char.ToUpper(result.Value) : result);
         }
 


### PR DESCRIPTION
> Ctrl = Control ?
> \- #309

I believe most people would like `Ctrl` rather than `Control` as default.

**Before**
![before](https://user-images.githubusercontent.com/7588612/51427324-95266a80-1bee-11e9-9b23-186e9d6abd88.gif)

**After**
![after](https://user-images.githubusercontent.com/7588612/51427325-9fe0ff80-1bee-11e9-9598-372ed5ff64ac.gif)