### PR TITLE
Change Import Video method to use ffmpeg instead.

### DIFF
--- a/ScreenToGif/Controls/RangeSlider.cs
+++ b/ScreenToGif/Controls/RangeSlider.cs
@@ -133,6 +133,9 @@ namespace ScreenToGif.Controls
         public static readonly RoutedEvent UpperValueChangedEvent = EventManager.RegisterRoutedEvent("UpperValueChanged", RoutingStrategy.Bubble, 
             typeof(RoutedEventHandler), typeof(RangeSlider));
 
+        public static readonly RoutedEvent SliderMouseUpEvent = EventManager.RegisterRoutedEvent("SliderMouseUp", RoutingStrategy.Bubble,
+            typeof(RoutedEventHandler), typeof(RangeSlider));
+
         public event RoutedEventHandler LowerValueChanged
         {
             add => AddHandler(LowerValueChangedEvent, value);
@@ -143,6 +146,12 @@ namespace ScreenToGif.Controls
         {
             add => AddHandler(UpperValueChangedEvent, value);
             remove => RemoveHandler(UpperValueChangedEvent, value);
+        }
+
+        public event RoutedEventHandler SliderMouseUp
+        {
+            add => AddHandler(SliderMouseUpEvent, value);
+            remove => RemoveHandler(SliderMouseUpEvent, value);
         }
 
         public void RaiseLowerValueChangedEvent()
@@ -160,6 +169,15 @@ namespace ScreenToGif.Controls
                 return;
 
             var newEventArgs = new RoutedEventArgs(UpperValueChangedEvent);
+            RaiseEvent(newEventArgs);
+        }
+
+        public void RaiseSliderMouseUp()
+        {
+            if (SliderMouseUpEvent == null || !IsLoaded)
+                return;
+
+            var newEventArgs = new RoutedEventArgs(SliderMouseUpEvent);
             RaiseEvent(newEventArgs);
         }
 
@@ -182,7 +200,7 @@ namespace ScreenToGif.Controls
             if (_lowerSlider != null)
             {
                 _lowerSlider.Value = LowerValue;
-                _lowerSlider.PreviewMouseUp += LowerSlider_MouseUp;
+                _lowerSlider.PreviewMouseUp += LowerSlider_PreviewMouseUp;
             }
 
             if (_upperSlider != null)
@@ -206,12 +224,14 @@ namespace ScreenToGif.Controls
         private void UpperSlider_PreviewMouseUp(object sender, MouseButtonEventArgs e)
         {
             UpperValue = Math.Max(_upperSlider.Value, _lowerSlider.Value);
+            this.RaiseSliderMouseUp();
             SetProgressBorder();
         }
 
-        private void LowerSlider_MouseUp(object sender, MouseButtonEventArgs e)
+        private void LowerSlider_PreviewMouseUp(object sender, MouseButtonEventArgs e)
         {
             LowerValue = Math.Min(_upperSlider.Value, _lowerSlider.Value);
+            this.RaiseSliderMouseUp();
             SetProgressBorder();
         }
 

--- a/ScreenToGif/Windows/Editor.xaml.cs
+++ b/ScreenToGif/Windows/Editor.xaml.cs
@@ -1396,7 +1396,7 @@ namespace ScreenToGif.Windows
                         param.UseGlobalColorTable = false;
                         param.MaximumNumberColors = UserSettings.All.MaximumColors;
                         param.RepeatCount = UserSettings.All.Looped ? (UserSettings.All.RepeatForever ? 0 : UserSettings.All.RepeatCount) : -1;
-                        param.Command = "-vsync 2 -safe 0 -f concat -i \"{0}\" {1} -y \"{2}\"";
+                        param.Command = "-vsync 2 -progress pipe:1 -safe 0 -f concat -i \"{0}\" {1} -y \"{2}\"";
                         param.ExtraParameters = UserSettings.All.ExtraParametersGif;
                         break;
                     case Export.Apng:

--- a/ScreenToGif/Windows/Other/VideoSource.xaml
+++ b/ScreenToGif/Windows/Other/VideoSource.xaml
@@ -48,7 +48,7 @@
 
         <c:RangeSlider x:Name="SelectionSlider" Grid.Row="3" Height="Auto" MinHeight="20" 
                        UpperValue="100" LowerValue="0" TickPlacement="BottomRight" Margin="5,5" IsEnabled="False"
-                       UpperValueChanged="SelectionSlider_UpperValueChanged" LowerValueChanged="SelectionSlider_LowerValueChanged"/>
+                       SliderMouseUp="SelectionSlider_MouseUp"/>
 
         <Grid x:Name="DetailsGrid" Grid.Row="4" Margin="0,0,0,5" Visibility="Visible">
             <Grid.RowDefinitions>
@@ -97,7 +97,7 @@
             <StackPanel Grid.Row="1" Grid.Column="6" Orientation="Horizontal" HorizontalAlignment="Left">
                 <c:IntegerUpDown x:Name="StartNumericUpDown" MinWidth="60" Margin="5" StepValue="10" Padding="2,0"
                                  Maximum="{Binding Value, ElementName=EndNumericUpDown}" Minimum="{Binding Minimum, ElementName=SelectionSlider}" 
-                                 Value="{Binding LowerValue, ElementName=SelectionSlider, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" 
+                                 Value="{Binding LowerValue, ElementName=SelectionSlider, Mode=OneWayToSource, UpdateSourceTrigger=PropertyChanged}" 
                                  ValueChanged="StartNumericUpDown_ValueChanged"/>
                 <Label Content="ms" Padding="0,0,5,0" VerticalContentAlignment="Center" Foreground="{DynamicResource Element.Foreground.Medium}"/>
             </StackPanel>
@@ -106,7 +106,7 @@
             <StackPanel Grid.Row="1" Grid.Column="7" Orientation="Horizontal" HorizontalAlignment="Left">
                 <c:IntegerUpDown x:Name="EndNumericUpDown" MinWidth="60" Margin="5" StepValue="10" Padding="2,0"
                                  Maximum="{Binding Maximum, ElementName=SelectionSlider}" Minimum="{Binding Value, ElementName=StartNumericUpDown}" 
-                                 Value="{Binding UpperValue, ElementName=SelectionSlider, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" 
+                                 Value="{Binding UpperValue, ElementName=SelectionSlider, Mode=OneWayToSource, UpdateSourceTrigger=PropertyChanged}" 
                                  ValueChanged="EndNumericUpDown_ValueChanged"/>
                 <Label Content="ms" Padding="0,0,5,0" VerticalContentAlignment="Center" Foreground="{DynamicResource Element.Foreground.Medium}"/>
             </StackPanel>


### PR DESCRIPTION
#378 

More precise capturing frames from videos.

Progress bar works fine with parsed ffmpeg output with -progress option. This trick could also be applied when you encode gif with ffmpeg. ~~I haven't done it yet.~~ EDIT: Done

In addition, due to laggy, unnecessary video jumping, Start/End time NumericUpDown no longer continuously change their value while dragging Selection Slider. Now only changes value when you finish drag on slider.

I just deleted whole old capturing methods, so ffmpeg is essential to import videos. Display warning status bar when trying to import vid and ffmpeg not set on program, commented out Editor.xaml.cs:4910 StatusList.Remove(~) for this.

I'm not good programmer. It will be very appreciated to improve these code.