### PR TITLE
Fix time format string not to ignore trailing zeros

### DIFF
--- a/ScreenToGif/Util/ClipBoard.cs
+++ b/ScreenToGif/Util/ClipBoard.cs
@@ -105,7 +105,7 @@ namespace ScreenToGif.Util
             foreach (var frameInfo in Items[index])
             {
                 //Changes the path of the image.
-                var filename = Path.Combine(recordingFolder, $"{pasteIndex} - {Path.GetFileNameWithoutExtension(frameInfo.Path)} {DateTime.Now:hh-mm-ss-FFFF}.png");
+                var filename = Path.Combine(recordingFolder, $"{pasteIndex} - {Path.GetFileNameWithoutExtension(frameInfo.Path)} {DateTime.Now:hh-mm-ss-ffff}.png");
 
                 //Copy the image to the folder.
                 File.Copy(frameInfo.Path, filename, true);

--- a/ScreenToGif/Windows/Editor.xaml.cs
+++ b/ScreenToGif/Windows/Editor.xaml.cs
@@ -4410,7 +4410,7 @@ namespace ScreenToGif.Windows
 
                 #region Each Frame
 
-                var fileName = Path.Combine(pathTemp, $"{index} {DateTime.Now:hh-mm-ss-FFFF}.png");
+                var fileName = Path.Combine(pathTemp, $"{index} {DateTime.Now:hh-mm-ss-ffff}.png");
 
                 using (var stream = new FileStream(fileName, FileMode.Create))
                 {
@@ -4438,7 +4438,7 @@ namespace ScreenToGif.Windows
 
         private List<FrameInfo> ImportFromImage(string sourceFileName, string pathTemp)
         {
-            var fileName = Path.Combine(pathTemp, $"{0} {DateTime.Now:hh-mm-ss-FFFF}.png");
+            var fileName = Path.Combine(pathTemp, $"{0} {DateTime.Now:hh-mm-ss-ffff}.png");
 
             #region Save the Image to the Recording Folder
 
@@ -4493,7 +4493,7 @@ namespace ScreenToGif.Windows
 
             foreach (var frame in frameList)
             {
-                var frameName = Path.Combine(pathTemp, $"{count} {DateTime.Now:hh-mm-ss-FFFF}.png");
+                var frameName = Path.Combine(pathTemp, $"{count} {DateTime.Now:hh-mm-ss-ffff}.png");
 
                 using (var stream = new FileStream(frameName, FileMode.Create))
                 {


### PR DESCRIPTION
Small bug fix. Current time format strings remove trailing zeros on frame's filename but they are important in Windows filename order.

hh-mm-ss-FFFF => hh-mm-ss-ffff
[reference](https://docs.microsoft.com/en-us/dotnet/standard/base-types/custom-date-and-time-format-strings?redirectedfrom=MSDN#FFFF_Specifier)