### PR TITLE
Fixing tiny typo in English localization at Insert Frame modal #623

### DIFF
--- a/ScreenToGif/Resources/Localization/StringResources.en.xaml
+++ b/ScreenToGif/Resources/Localization/StringResources.en.xaml
@@ -545,7 +545,7 @@
     <s:String x:Key="S.InsertFrames.CanvasSize">Canvas size:</s:String>
     <s:String x:Key="S.InsertFrames.FitCanvas">Fit Image on Canvas</s:String>
     <s:String x:Key="S.InsertFrames.FitCanvas.Info">Resizes the canvas to fit both images inside (from the top left corner).</s:String>
-    <s:String x:Key="S.InsertFrames.DifferentSizes">There is a difference beetwen frame sizes. You need to solve this before inserting the frames.</s:String>
+    <s:String x:Key="S.InsertFrames.DifferentSizes">There is a difference between frame sizes. You need to solve this before inserting the frames.</s:String>
     <s:String x:Key="S.InsertFrames.InsertedFrames">New Frame(s)</s:String>
     <s:String x:Key="S.InsertFrames.CurrentFrames">Current Frame(s)</s:String>
     <s:String x:Key="S.InsertFrames.ImageSize">Image size:</s:String>


### PR DESCRIPTION
Fixing tiny typo `beetwen` to `between`.

Relates #623 