### PR TITLE
Adding SharpDX Nuget reference

### DIFF
--- a/ScreenToGif/Resources/Localization/StringResources.en.xaml
+++ b/ScreenToGif/Resources/Localization/StringResources.en.xaml
@@ -545,7 +545,7 @@
     <s:String x:Key="S.InsertFrames.CanvasSize">Canvas size:</s:String>
     <s:String x:Key="S.InsertFrames.FitCanvas">Fit Image on Canvas</s:String>
     <s:String x:Key="S.InsertFrames.FitCanvas.Info">Resizes the canvas to fit both images inside (from the top left corner).</s:String>
-    <s:String x:Key="S.InsertFrames.DifferentSizes">There is a difference beetwen frame sizes. You need to solve this before inserting the frames.</s:String>
+    <s:String x:Key="S.InsertFrames.DifferentSizes">There is a difference between frame sizes. You need to solve this before inserting the frames.</s:String>
     <s:String x:Key="S.InsertFrames.InsertedFrames">New Frame(s)</s:String>
     <s:String x:Key="S.InsertFrames.CurrentFrames">Current Frame(s)</s:String>
     <s:String x:Key="S.InsertFrames.ImageSize">Image size:</s:String>

--- a/ScreenToGif/ScreenToGif.csproj
+++ b/ScreenToGif/ScreenToGif.csproj
@@ -107,16 +107,13 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="SharpDX, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\SharpDx\Desktop\Direct3D11.1\ScreenCapture\bin\Debug\SharpDX.dll</HintPath>
+      <HintPath>..\packages\SharpDX.4.2.0\lib\net45\SharpDX.dll</HintPath>
     </Reference>
     <Reference Include="SharpDX.Direct3D11, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\SharpDx\Desktop\Direct3D11.1\ScreenCapture\bin\Debug\SharpDX.Direct3D11.dll</HintPath>
+      <HintPath>..\packages\SharpDX.Direct3D11.4.2.0\lib\net45\SharpDX.Direct3D11.dll</HintPath>
     </Reference>
     <Reference Include="SharpDX.DXGI, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\SharpDx\Desktop\Direct3D11.1\ScreenCapture\bin\Debug\SharpDX.DXGI.dll</HintPath>
+      <HintPath>..\packages\SharpDX.DXGI.4.2.0\lib\net45\SharpDX.DXGI.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
@@ -722,6 +719,7 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="Controls\LightWindow.cs" />
+    <None Include="packages.config" />
     <None Include="Themes\Old.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>

--- a/ScreenToGif/packages.config
+++ b/ScreenToGif/packages.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="SharpDX" version="4.2.0" targetFramework="net48" />
+  <package id="SharpDX.Direct3D11" version="4.2.0" targetFramework="net48" />
+  <package id="SharpDX.DXGI" version="4.2.0" targetFramework="net48" />
+</packages>


### PR DESCRIPTION
Current reference deleted and nuget reference from SharpDX DLLs added.
So, any contributor can build&run the solution without install SharpDX DLLs: Nuget downloads the DLLs and adds the reference automatically.