### PR TITLE
[RFC] suppress TargetNullValue on .mp4 extension

### DIFF
--- a/ScreenToGif/Windows/Editor.xaml
+++ b/ScreenToGif/Windows/Editor.xaml
@@ -2647,7 +2647,7 @@
                                     </ComboBox>
 
                                     <ComboBox Grid.Column="1" Name="FileTypeVideoComboBox" Margin="1,3" MinHeight="25" ToolTip="{DynamicResource S.SaveAs.File.Format}"
-                                              SelectedItem="{Binding Source={x:Static u:UserSettings.All}, Path=LatestVideoExtension, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, TargetNullValue='.mp4'}"
+                                              SelectedItem="{Binding Source={x:Static u:UserSettings.All}, Path=LatestVideoExtension, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                               Visibility="{Binding IsChecked, ElementName=VideoRadioButton, Converter={StaticResource Bool2Visibility}}" SelectionChanged="SaveType_Checked">
                                         <s:String>.avi</s:String>
                                         <s:String>.mkv</s:String>


### PR DESCRIPTION
a null value in `LatestVideoExtension` user settings will make user settings saving crash and Settings.xaml emptied.

When `TargetNullValue` is set to ".mp4" value, `LatestVideoExtension` is set to "null" when the value ".mp4" is selected in the combo box. Then `UserSettings.Save` method will crash with a `NullReferenceException`.

I don't see the point of setting it to null so I think the simplier fix is to remove `TargetNullValue` on the binding.

Closes #639