### PR TITLE
Excluding CaptureBlt flag on RDP session

### DIFF
--- a/ScreenToGif/Util/Capture/ImageCapture.cs
+++ b/ScreenToGif/Util/Capture/ImageCapture.cs
@@ -15,7 +15,7 @@ namespace ScreenToGif.Util.Capture
         protected internal IntPtr CompatibleDeviceContext;
         protected internal IntPtr CompatibleBitmap;
         protected internal IntPtr OldBitmap;
-        
+
         protected internal int CursorStep { get; set; }
 
         #endregion
@@ -43,8 +43,15 @@ namespace ScreenToGif.Util.Capture
             {
                 new System.Security.Permissions.UIPermission(System.Security.Permissions.UIPermissionWindow.AllWindows).Demand();
 
+                var pixelOp = Native.CopyPixelOperation.SourceCopy;
+
+                if (!System.Windows.Forms.SystemInformation.TerminalServerSession)
+                {
+                    pixelOp |= Native.CopyPixelOperation.CaptureBlt;
+                }
+
                 //var success = Native.BitBlt(CompatibleDeviceContext, 0, 0, Width, Height, WindowDeviceContext, Left, Top, Native.CopyPixelOperation.SourceCopy | Native.CopyPixelOperation.CaptureBlt);
-                var success = Native.StretchBlt(CompatibleDeviceContext, 0, 0, StartWidth, StartHeight, WindowDeviceContext, Left, Top, Width, Height, Native.CopyPixelOperation.SourceCopy | Native.CopyPixelOperation.CaptureBlt);
+                var success = Native.StretchBlt(CompatibleDeviceContext, 0, 0, StartWidth, StartHeight, WindowDeviceContext, Left, Top, Width, Height, pixelOp);
 
                 if (!success)
                     return FrameCount;
@@ -71,8 +78,15 @@ namespace ScreenToGif.Util.Capture
             {
                 new System.Security.Permissions.UIPermission(System.Security.Permissions.UIPermissionWindow.AllWindows).Demand();
 
+                var pixelOp = Native.CopyPixelOperation.SourceCopy;
+
+                if (!System.Windows.Forms.SystemInformation.TerminalServerSession)
+                {
+                    pixelOp |= Native.CopyPixelOperation.CaptureBlt;
+                }
+
                 //var success = Native.BitBlt(CompatibleDeviceContext, 0, 0, Width, Height, WindowDeviceContext, Left, Top, Native.CopyPixelOperation.SourceCopy | Native.CopyPixelOperation.CaptureBlt);
-                var success = Native.StretchBlt(CompatibleDeviceContext, 0, 0, StartWidth, StartHeight, WindowDeviceContext, Left, Top, Width, Height, Native.CopyPixelOperation.SourceCopy | Native.CopyPixelOperation.CaptureBlt);
+                var success = Native.StretchBlt(CompatibleDeviceContext, 0, 0, StartWidth, StartHeight, WindowDeviceContext, Left, Top, Width, Height, pixelOp);
 
                 if (!success)
                     return FrameCount;


### PR DESCRIPTION
This PR fixes the mouse jittering when recording over RDP.

From the docs:

> CaptureBlt: Windows that are layered on top of your window are included in the resulting image. By default, the image contains only your window. **Note that this generally cannot be used for printing device contexts**.

Now I don't really know how a RDP device context is treated internally, but a lot of code samples I saw online treat printing and RDP context the same way. The downside of this approach is that we don't get support for recording layered windows anymore over RDP. But it's certainly better than the jittering we had before. Cheers.

Fixes https://github.com/NickeManarin/ScreenToGif/issues/622