### PR TITLE
Added option in Image Resizer to use the "High Quality" scaling

### DIFF
--- a/ScreenToGif/ImageUtil/ImageMethods.cs
+++ b/ScreenToGif/ImageUtil/ImageMethods.cs
@@ -1566,20 +1566,21 @@ namespace ScreenToGif.ImageUtil
         /// <param name="height">The height of the image.</param>
         /// <param name="margin">Cut margin.</param>
         /// <param name="dpi">The DPI of the image.</param>
+        /// <param name="scalingQuality">Scaling Quality to use when resizing. <seealso cref="System.Windows.Media.BitmapScalingMode"/></param>
         /// <returns>A resized ImageSource</returns>
-        public static BitmapFrame ResizeImage(BitmapImage source, int width, int height, int margin = 0, double dpi = 96d, bool useHighQualityScale = false)
+        public static BitmapFrame ResizeImage(BitmapImage source, int width, int height, int margin = 0, double dpi = 96d, BitmapScalingMode scalingQuality = BitmapScalingMode.Unspecified)
         {
             var scale = dpi / 96d;
 
             var drawingVisual = new DrawingVisual();
             using (var drawingContext = drawingVisual.RenderOpen())
             {
-                if (useHighQualityScale)
+                if (scalingQuality != BitmapScalingMode.Unspecified)
                 {
                     DrawingGroup dg = new DrawingGroup();
                     using (DrawingContext context = dg.Open())
                     {
-                        RenderOptions.SetBitmapScalingMode(dg, BitmapScalingMode.Fant);
+                        RenderOptions.SetBitmapScalingMode(dg, scalingQuality);
                         context.DrawImage(source, new Rect(0, 0, width / scale, height / scale));
                     }
                     drawingContext.DrawDrawing(dg);

--- a/ScreenToGif/ImageUtil/ImageMethods.cs
+++ b/ScreenToGif/ImageUtil/ImageMethods.cs
@@ -1567,13 +1567,28 @@ namespace ScreenToGif.ImageUtil
         /// <param name="margin">Cut margin.</param>
         /// <param name="dpi">The DPI of the image.</param>
         /// <returns>A resized ImageSource</returns>
-        public static BitmapFrame ResizeImage(BitmapImage source, int width, int height, int margin = 0, double dpi = 96d)
+        public static BitmapFrame ResizeImage(BitmapImage source, int width, int height, int margin = 0, double dpi = 96d, bool useHighQualityScale = false)
         {
             var scale = dpi / 96d;
 
             var drawingVisual = new DrawingVisual();
             using (var drawingContext = drawingVisual.RenderOpen())
-                drawingContext.DrawImage(source, new Rect(0, 0, width / scale, height / scale));
+            {
+                if (useHighQualityScale)
+                {
+                    DrawingGroup dg = new DrawingGroup();
+                    using (DrawingContext context = dg.Open())
+                    {
+                        RenderOptions.SetBitmapScalingMode(dg, BitmapScalingMode.Fant);
+                        context.DrawImage(source, new Rect(0, 0, width / scale, height / scale));
+                    }
+                    drawingContext.DrawDrawing(dg);
+                }
+                else
+                {
+                    drawingContext.DrawImage(source, new Rect(0, 0, width / scale, height / scale));
+                }                
+            }            
 
             //(int)Math.Round(width * scale)
 

--- a/ScreenToGif/Resources/Localization/StringResources.en.xaml
+++ b/ScreenToGif/Resources/Localization/StringResources.en.xaml
@@ -1041,6 +1041,7 @@
     <s:String x:Key="S.Resize.NewProperties">New Properties</s:String>
     <s:String x:Key="S.Resize.Dpi2">DPI:</s:String>
     <s:String x:Key="S.Resize.KeepAspect">Keep the aspect ratio.</s:String>
+    <s:String x:Key="S.Resize.HighQalityScaling">Use high quality scaling.</s:String>
     <s:String x:Key="S.Resize.Warning">You have to select a different value to apply the Resize action to.</s:String>
     
     <!--Editor • Crop-->

--- a/ScreenToGif/Resources/Localization/StringResources.en.xaml
+++ b/ScreenToGif/Resources/Localization/StringResources.en.xaml
@@ -1041,7 +1041,12 @@
     <s:String x:Key="S.Resize.NewProperties">New Properties</s:String>
     <s:String x:Key="S.Resize.Dpi2">DPI:</s:String>
     <s:String x:Key="S.Resize.KeepAspect">Keep the aspect ratio.</s:String>
-    <s:String x:Key="S.Resize.HighQalityScaling">Use high quality scaling.</s:String>
+    <s:String x:Key="S.Resize.Options">Options</s:String>
+    <s:String x:Key="S.Resize.ScalingQuality">Scaling Quality:</s:String>
+    <s:String x:Key="S.Resize.ScalingQuality.Fant">Fant (higher quality)</s:String>
+    <s:String x:Key="S.Resize.ScalingQuality.Linear">Linear (lower quality)</s:String>
+    <s:String x:Key="S.Resize.ScalingQuality.NearestNeighbor">Nearest neighbor (lower quality and faster)</s:String>
+    
     <s:String x:Key="S.Resize.Warning">You have to select a different value to apply the Resize action to.</s:String>
     
     <!--Editor • Crop-->

--- a/ScreenToGif/Util/Enums.cs
+++ b/ScreenToGif/Util/Enums.cs
@@ -638,4 +638,16 @@
         PerMinute,
         PerHour
     }
+
+    /// <summary>
+    /// Scaling quality options for resizing
+    /// This enum is a subset of <seealso cref="System.Windows.Media.BitmapScalingMode"/>.
+    /// It is used to expose this enum to the Editor and choose which options are availabe
+    /// </summary>
+    public enum ScalingMethod
+    {
+        Fant = System.Windows.Media.BitmapScalingMode.Fant,
+        Linear = System.Windows.Media.BitmapScalingMode.Linear,
+        NearestNeighbor = System.Windows.Media.BitmapScalingMode.NearestNeighbor
+    }
 }

--- a/ScreenToGif/Windows/Editor.xaml
+++ b/ScreenToGif/Windows/Editor.xaml
@@ -2903,7 +2903,8 @@
                                 <RowDefinition Height="27"/>
                                 <RowDefinition Height="Auto"/>
                                 <RowDefinition Height="Auto"/>
-                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="27"/>
+                                <RowDefinition Height="Auto"/>                                
                             </Grid.RowDefinitions>
 
                             <n:LabelSeparator Grid.Row="0" Text="{DynamicResource S.Resize.CurrentProperties}"/>
@@ -2946,7 +2947,26 @@
                             </Grid>
 
                             <n:ExtendedCheckBox Grid.Row="4" x:Name="KeepAspectCheckBox" Text="{DynamicResource S.Resize.KeepAspect}" Margin="10,5" IsChecked="True" Checked="KeepAspectCheckBox_Checked"/>
-                            <n:ExtendedCheckBox Grid.Row="5" x:Name="UseHighQualityScaling" Text="{DynamicResource S.Resize.HighQalityScaling}" Margin="10,5" IsChecked="False" />
+
+                            <n:LabelSeparator Grid.Row="5" Text="{DynamicResource S.Resize.Options}"/>
+                            <Grid Grid.Row="6" Margin="10,0,0,0">
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto"/>
+                                </Grid.RowDefinitions>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                
+                                <TextBlock Grid.Row="1" Grid.Column="0" Text="{DynamicResource S.Resize.ScalingQuality}" VerticalAlignment="Center" Padding="0" Foreground="{DynamicResource Element.Foreground.Medium}"/>
+                                <ComboBox Grid.Row="1" Grid.Column="1" x:Name="ResizeScalingQuality" Margin="10,5" MaxWidth="150" SelectedValuePath="Tag" >
+                                    <ComboBoxItem Tag="{x:Static u:ScalingMethod.Fant}" Content="{DynamicResource S.Resize.ScalingQuality.Fant}" />
+                                    <ComboBoxItem Tag="{x:Static u:ScalingMethod.Linear}" Content="{DynamicResource S.Resize.ScalingQuality.Linear}" IsSelected="True"/>
+                                    <ComboBoxItem Tag="{x:Static u:ScalingMethod.NearestNeighbor}" Content="{DynamicResource S.Resize.ScalingQuality.NearestNeighbor}"/>
+                                </ComboBox>
+                            </Grid>
+
+                            
                         </Grid>
 
                         <Grid x:Name="CropGrid" Visibility="Collapsed">

--- a/ScreenToGif/Windows/Editor.xaml
+++ b/ScreenToGif/Windows/Editor.xaml
@@ -2903,6 +2903,7 @@
                                 <RowDefinition Height="27"/>
                                 <RowDefinition Height="Auto"/>
                                 <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
                             </Grid.RowDefinitions>
 
                             <n:LabelSeparator Grid.Row="0" Text="{DynamicResource S.Resize.CurrentProperties}"/>
@@ -2945,6 +2946,7 @@
                             </Grid>
 
                             <n:ExtendedCheckBox Grid.Row="4" x:Name="KeepAspectCheckBox" Text="{DynamicResource S.Resize.KeepAspect}" Margin="10,5" IsChecked="True" Checked="KeepAspectCheckBox_Checked"/>
+                            <n:ExtendedCheckBox Grid.Row="5" x:Name="UseHighQualityScaling" Text="{DynamicResource S.Resize.HighQalityScaling}" Margin="10,5" IsChecked="False" />
                         </Grid>
 
                         <Grid x:Name="CropGrid" Visibility="Collapsed">

--- a/ScreenToGif/Windows/Editor.xaml.cs
+++ b/ScreenToGif/Windows/Editor.xaml.cs
@@ -2785,8 +2785,11 @@ namespace ScreenToGif.Windows
 
             Cursor = Cursors.AppStarting;
 
+            var scalingQuality = ScalingMethod.Linear;
+            Enum.TryParse<ScalingMethod>((ResizeScalingQuality.SelectedItem as ComboBoxItem).Tag.ToString(), out scalingQuality);
+
             _resizeFramesDel = Resize;
-            _resizeFramesDel.BeginInvoke(WidthResizeNumericUpDown.Value, HeightResizeNumericUpDown.Value, DpiNumericUpDown.Value, UseHighQualityScaling.IsChecked ?? false, ResizeCallback, null);
+            _resizeFramesDel.BeginInvoke(WidthResizeNumericUpDown.Value, HeightResizeNumericUpDown.Value, DpiNumericUpDown.Value, (BitmapScalingMode)scalingQuality, ResizeCallback, null);
 
             ClosePanel();
 
@@ -6512,11 +6515,11 @@ namespace ScreenToGif.Windows
 
         #region Async Resize
 
-        private delegate void ResizeFrames(int width, int height, double dpi, bool useHighQualityScale);
+        private delegate void ResizeFrames(int width, int height, double dpi, BitmapScalingMode scalingQuality);
 
         private ResizeFrames _resizeFramesDel;
 
-        private void Resize(int width, int height, double dpi, bool useHighQualityScaling)
+        private void Resize(int width, int height, double dpi, BitmapScalingMode scalingQuality)
         {
             ShowProgress(LocalizationHelper.Get("S.Editor.ResizingFrames"), Project.Frames.Count);
 
@@ -6526,7 +6529,7 @@ namespace ScreenToGif.Windows
             foreach (var frame in Project.Frames)
             {
                 var png = new PngBitmapEncoder();
-                png.Frames.Add(ImageMethods.ResizeImage((BitmapImage)frame.Path.SourceFrom(), width, height, 0, dpi, useHighQualityScaling));
+                png.Frames.Add(ImageMethods.ResizeImage((BitmapImage)frame.Path.SourceFrom(), width, height, 0, dpi, scalingQuality));
 
                 using (Stream stm = File.OpenWrite(frame.Path))
                     png.Save(stm);

--- a/ScreenToGif/Windows/Editor.xaml.cs
+++ b/ScreenToGif/Windows/Editor.xaml.cs
@@ -2786,7 +2786,7 @@ namespace ScreenToGif.Windows
             Cursor = Cursors.AppStarting;
 
             _resizeFramesDel = Resize;
-            _resizeFramesDel.BeginInvoke(WidthResizeNumericUpDown.Value, HeightResizeNumericUpDown.Value, DpiNumericUpDown.Value, ResizeCallback, null);
+            _resizeFramesDel.BeginInvoke(WidthResizeNumericUpDown.Value, HeightResizeNumericUpDown.Value, DpiNumericUpDown.Value, UseHighQualityScaling.IsChecked ?? false, ResizeCallback, null);
 
             ClosePanel();
 
@@ -6512,11 +6512,11 @@ namespace ScreenToGif.Windows
 
         #region Async Resize
 
-        private delegate void ResizeFrames(int width, int height, double dpi);
+        private delegate void ResizeFrames(int width, int height, double dpi, bool useHighQualityScale);
 
         private ResizeFrames _resizeFramesDel;
 
-        private void Resize(int width, int height, double dpi)
+        private void Resize(int width, int height, double dpi, bool useHighQualityScaling)
         {
             ShowProgress(LocalizationHelper.Get("S.Editor.ResizingFrames"), Project.Frames.Count);
 
@@ -6526,7 +6526,7 @@ namespace ScreenToGif.Windows
             foreach (var frame in Project.Frames)
             {
                 var png = new PngBitmapEncoder();
-                png.Frames.Add(ImageMethods.ResizeImage((BitmapImage)frame.Path.SourceFrom(), width, height, 0, dpi));
+                png.Frames.Add(ImageMethods.ResizeImage((BitmapImage)frame.Path.SourceFrom(), width, height, 0, dpi, useHighQualityScaling));
 
                 using (Stream stm = File.OpenWrite(frame.Path))
                     png.Save(stm);


### PR DESCRIPTION
New option in the Image Resize function in the Editor that will use the "High Quality" scaling option while rendering.  This is arguably "high quality", but for some types of images this does produce more readable results and for other's it doesn't.  They are at least more anti-aliased. It defaults to off so the current behavior is preserved.

In the code, I found the creating a DrawingGroup is the only way to engage the SetBitmapScalingMode.  When I profiled it, it did take more ram, but then so does the "Fant" scaling mode so...

I am not in love with the term "Use high quality scaling." but didn't know a better term.

I only entered the string resource for English.  I can get Russian and Chinese from native speakers if you'd like, but I'll only do that if you like the PR.