### PR TITLE
Add option to ignore simulated keystrokes

### DIFF
--- a/ScreenToGif/Model/KeyStrokesModel.cs
+++ b/ScreenToGif/Model/KeyStrokesModel.cs
@@ -9,6 +9,7 @@ namespace ScreenToGif.Model
         #region Variables
 
         private bool _ignoreNonModifiers;
+        private bool _ignoreInjected;
         private bool _earlier;
         private double _earlierBy;
         private string _separator;
@@ -39,6 +40,12 @@ namespace ScreenToGif.Model
         {
             get => _ignoreNonModifiers;
             set => SetProperty(ref _ignoreNonModifiers, value);
+        }
+
+        public bool KeyStrokesIgnoreInjected
+        {
+            get => _ignoreInjected;
+            set => SetProperty(ref _ignoreInjected, value);
         }
 
         public bool KeyStrokesEarlier
@@ -179,6 +186,7 @@ namespace ScreenToGif.Model
             return new KeyStrokesModel
             {
                 KeyStrokesIgnoreNonModifiers = true,
+                KeyStrokesIgnoreInjected = false,
                 KeyStrokesEarlier = false,
                 KeyStrokesEarlierBy = 500,
                 KeyStrokesExtended = true,
@@ -205,6 +213,7 @@ namespace ScreenToGif.Model
             return new KeyStrokesModel
             {
                 KeyStrokesIgnoreNonModifiers = UserSettings.All.KeyStrokesIgnoreNonModifiers,
+                KeyStrokesIgnoreInjected = UserSettings.All.KeyStrokesIgnoreInjected,
                 KeyStrokesEarlier = UserSettings.All.KeyStrokesEarlier,
                 KeyStrokesEarlierBy = UserSettings.All.KeyStrokesEarlierBy,
                 KeyStrokesExtended = UserSettings.All.KeyStrokesExtended,

--- a/ScreenToGif/Resources/Localization/StringResources.en.xaml
+++ b/ScreenToGif/Resources/Localization/StringResources.en.xaml
@@ -1178,6 +1178,8 @@
     <s:String x:Key="S.KeyStrokes.Edit">Edit your key strokes</s:String>
     <s:String x:Key="S.KeyStrokes.IgnoreModifiers">Ignore Ctrl, Alt, Shift, and Windows keys while not being used as modifiers.</s:String>
     <s:String x:Key="S.KeyStrokes.IgnoreModifiers.Info">It will ignore lone key presses such as "Control", but it will not ignore "Control + C".</s:String>
+    <s:String x:Key="S.KeyStrokes.IgnoreInjected">Ignore software simulated keystrokes.</s:String>
+    <s:String x:Key="S.KeyStrokes.IgnoreInjected.Info">Only record user input keystrokes.</s:String>
     <s:String x:Key="S.KeyStrokes.Extend">Extend the exhibition of the key strokes.</s:String>
     <s:String x:Key="S.KeyStrokes.Earlier">Start the exhibition of the key strokes earlier.</s:String>
     <s:String x:Key="S.KeyStrokes.By">By (ms):</s:String>

--- a/ScreenToGif/Resources/Localization/StringResources.zh.xaml
+++ b/ScreenToGif/Resources/Localization/StringResources.zh.xaml
@@ -1195,6 +1195,8 @@
     <s:String x:Key="S.KeyStrokes.Edit">编辑键盘按键</s:String>
     <s:String x:Key="S.KeyStrokes.IgnoreModifiers">忽略 Ctrl、Alt、Shift 和 Windows 键，而不将其用作修饰符。</s:String>
     <s:String x:Key="S.KeyStrokes.IgnoreModifiers.Info">它将忽略诸如“Control”这样单独的按键, 但它不会忽略“Control + C”。</s:String>
+    <s:String x:Key="S.KeyStrokes.IgnoreInjected">忽略软件模拟的按键。</s:String>
+    <s:String x:Key="S.KeyStrokes.IgnoreInjected.Info">仅记录用户实际输入的按键。</s:String>
     <s:String x:Key="S.KeyStrokes.Extend">延长按键显示时间</s:String>
     <s:String x:Key="S.KeyStrokes.Earlier">早些时候开始展示击键。</s:String>
     <s:String x:Key="S.KeyStrokes.By">长度 (ms)</s:String>

--- a/ScreenToGif/Resources/Settings.xaml
+++ b/ScreenToGif/Resources/Settings.xaml
@@ -369,6 +369,7 @@
     <!--Editor • KeyStrokes-->
     <s:Boolean x:Key="IsKeyStrokesKeysExpanded">True</s:Boolean>
     <s:Boolean x:Key="KeyStrokesIgnoreNonModifiers">True</s:Boolean>
+    <s:Boolean x:Key="KeyStrokesIgnoreInjected">False</s:Boolean>
     <s:Boolean x:Key="KeyStrokesEarlier">False</s:Boolean>
     <s:Double x:Key="KeyStrokesEarlierBy">500.0</s:Double>
     <s:Boolean x:Key="KeyStrokesExtended">True</s:Boolean>

--- a/ScreenToGif/UserControls/KeyStrokesPanel.xaml
+++ b/ScreenToGif/UserControls/KeyStrokesPanel.xaml
@@ -44,6 +44,7 @@
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
                 </Grid.RowDefinitions>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="Auto"/>
@@ -55,25 +56,29 @@
                                     IsChecked="{Binding KeyStrokesIgnoreNonModifiers, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                     ToolTip="{DynamicResource S.KeyStrokes.IgnoreModifiers.Info}"/>
 
-                <n:ExtendedCheckBox Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="3" Text="{DynamicResource S.KeyStrokes.Extend}" Margin="0,5"
+                <n:ExtendedCheckBox Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="3" Text="{DynamicResource S.KeyStrokes.IgnoreInjected}" Margin="0,5"
+                                    IsChecked="{Binding KeyStrokesIgnoreInjected, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                    ToolTip="{DynamicResource S.KeyStrokes.IgnoreInjected.Info}"/>
+
+                <n:ExtendedCheckBox Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="3" Text="{DynamicResource S.KeyStrokes.Extend}" Margin="0,5"
                                     IsChecked="{Binding KeyStrokesExtended, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
 
-                <StackPanel Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="3" Orientation="Horizontal" Margin="10,0,0,0" 
+                <StackPanel Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="3" Orientation="Horizontal" Margin="10,0,0,0" 
                             Visibility="{Binding KeyStrokesExtended, Converter={StaticResource Bool2Visibility}}">
                     <TextBlock Text="{DynamicResource S.KeyStrokes.By}" VerticalAlignment="Center" Foreground="{DynamicResource Element.Foreground.Medium}"/>
                     <n:IntegerUpDown Minimum="10" Maximum="1000" Margin="5" MinWidth="70" Value="{Binding KeyStrokesDelay, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
                 </StackPanel>
 
-                <n:ExtendedCheckBox Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="3" Text="{DynamicResource S.KeyStrokes.Earlier}" Margin="0,5"
+                <n:ExtendedCheckBox Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="3" Text="{DynamicResource S.KeyStrokes.Earlier}" Margin="0,5"
                                     IsChecked="{Binding KeyStrokesEarlier, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
 
-                <StackPanel Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="3" Orientation="Horizontal" Margin="10,0,0,0" 
+                <StackPanel Grid.Row="6" Grid.Column="0" Grid.ColumnSpan="3" Orientation="Horizontal" Margin="10,0,0,0" 
                             Visibility="{Binding KeyStrokesEarlier, Converter={StaticResource Bool2Visibility}}">
                     <TextBlock Text="{DynamicResource S.KeyStrokes.By}" VerticalAlignment="Center" Foreground="{DynamicResource Element.Foreground.Medium}"/>
                     <n:IntegerUpDown Minimum="10" Maximum="1000" Margin="5" MinWidth="70" Value="{Binding KeyStrokesEarlierBy, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
                 </StackPanel>
 
-                <TextBlock Grid.Row="6" Grid.Column="0" Text="{DynamicResource S.KeyStrokes.Separator}" VerticalAlignment="Center" Foreground="{DynamicResource Element.Foreground.Medium}"/>
+                <TextBlock Grid.Row="7" Grid.Column="0" Text="{DynamicResource S.KeyStrokes.Separator}" VerticalAlignment="Center" Foreground="{DynamicResource Element.Foreground.Medium}"/>
                 <n:ExtendedTextBox Grid.Row="6" Grid.Column="1" Margin="5,3" MinWidth="70" Text="{Binding KeyStrokesSeparator, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
             </Grid>
         </Expander>

--- a/ScreenToGif/Util/InputHook/CustomKeyEventArgs.cs
+++ b/ScreenToGif/Util/InputHook/CustomKeyEventArgs.cs
@@ -12,12 +12,15 @@ namespace ScreenToGif.Util.InputHook
 
         public bool IsUppercase { get; }
 
+        public bool IsInjected { get; }
+
         public bool Handled { get; private set; }
 
-        public CustomKeyEventArgs(Key key, bool isUppercase = false)
+        public CustomKeyEventArgs(Key key, bool isUppercase = false, bool isInjected = false)
         {
             Key = key;
             IsUppercase = isUppercase;
+            IsInjected = isInjected;
         }
     }
 }

--- a/ScreenToGif/Util/InputHook/InputHook.cs
+++ b/ScreenToGif/Util/InputHook/InputHook.cs
@@ -878,6 +878,7 @@ namespace ScreenToGif.Util.InputHook
 
             //Read structure KeyboardHookStruct at lParam
             var keyboard = (KeyboardHookStruct)Marshal.PtrToStructure(lParam, typeof(KeyboardHookStruct));
+            var isInjected = (keyboard.Flags & 0x10) != 0;
 
             if (KeyDown != null && (wParam == MessageKeydown || wParam == MessageSystemKeyDown))
             {
@@ -885,8 +886,9 @@ namespace ScreenToGif.Util.InputHook
 
                 var isDownShift = (GetKeyState(KeyShift) & 0x80) == 0x80;
                 var isDownCapslock = GetKeyState(KeyCapital) != 0;
+             
 
-                var e = new CustomKeyEventArgs(KeyInterop.KeyFromVirtualKey(keyboard.KeyCode), isDownCapslock ^ isDownShift);
+                var e = new CustomKeyEventArgs(KeyInterop.KeyFromVirtualKey(keyboard.KeyCode), isDownCapslock ^ isDownShift, isInjected);
 
                 KeyDown?.Invoke(this, e);
 
@@ -925,7 +927,7 @@ namespace ScreenToGif.Util.InputHook
             {
                 #region Raise KeyUp
 
-                var e = new CustomKeyEventArgs(KeyInterop.KeyFromVirtualKey(keyboard.KeyCode));
+                var e = new CustomKeyEventArgs(KeyInterop.KeyFromVirtualKey(keyboard.KeyCode), false, isInjected);
 
                 KeyUp?.Invoke(this, e);
 

--- a/ScreenToGif/Util/Other.cs
+++ b/ScreenToGif/Util/Other.cs
@@ -347,7 +347,7 @@ namespace ScreenToGif.Util
         public static List<FrameInfo> CopyList(this List<FrameInfo> target)
         {
             return new List<FrameInfo>(target.Select(s => new FrameInfo(s.Path, s.Delay, s.CursorX, s.CursorY, s.WasClicked, 
-                s.KeyList != null ? new List<SimpleKeyGesture>(s.KeyList.Select(y => new SimpleKeyGesture(y.Key, y.Modifiers, y.IsUppercase))) : null, s.Index)));
+                s.KeyList != null ? new List<SimpleKeyGesture>(s.KeyList.Select(y => new SimpleKeyGesture(y.Key, y.Modifiers, y.IsUppercase, y.IsInjected))) : null, s.Index)));
         }
 
         /// <summary>

--- a/ScreenToGif/Util/SimpleKeyGesture.cs
+++ b/ScreenToGif/Util/SimpleKeyGesture.cs
@@ -31,6 +31,9 @@ namespace ScreenToGif.Util
         [DataMember]
         public bool IsUppercase { get; set; }
 
+        [DataMember]
+        public bool IsInjected { get; set; }
+
         /// <summary>Gets a string representation of this <see cref="T:System.Windows.Input.KeyGesture" />.</summary>
         /// <returns>The display string for this <see cref="T:System.Windows.Input.KeyGesture" />. The default value is <see cref="F:System.String.Empty" />.</returns>
         [IgnoreDataMember]
@@ -66,11 +69,12 @@ namespace ScreenToGif.Util
         /// <param name="key">The key associated with the gesture.</param>
         /// <param name="modifiers">The modifier keys associated with the gesture.</param>
         /// <param name="isUppercase">True if the letter is uppercase.</param>
+        /// <param name="isInjected">True if keystroke was simulated by other software.</param>
         /// <exception cref="T:System.ComponentModel.InvalidEnumArgumentException">
         /// <paramref name="modifiers" /> is not a valid <see cref="T:System.Windows.Input.ModifierKeys" />-or-<paramref name="key" /> is not a valid <see cref="T:System.Windows.Input.Key" />.</exception>
         /// <exception cref="T:System.NotSupportedException">
         /// <paramref name="key" /> and <paramref name="modifiers" /> do not form a valid <see cref="T:System.Windows.Input.KeyGesture" />.</exception>
-        public SimpleKeyGesture(Key key, ModifierKeys modifiers, bool isUppercase = false) : this(key, modifiers, string.Empty, isUppercase)
+        public SimpleKeyGesture(Key key, ModifierKeys modifiers, bool isUppercase = false, bool isInjected = false) : this(key, modifiers, string.Empty, isUppercase, isInjected)
         {
             //Remove the modifier key, if it's the same as the detected pressend key.
             if (key == Key.LeftCtrl || key == Key.LeftShift || key == Key.LeftAlt || key == Key.LWin || key == Key.RightCtrl || key == Key.RightShift || key == Key.RightAlt || key == Key.RWin)
@@ -82,13 +86,14 @@ namespace ScreenToGif.Util
         /// <param name="modifiers">The modifier keys associated with the gesture.</param>
         /// <param name="displayString">A string representation of the <see cref="T:System.Windows.Input.KeyGesture" />.</param>
         /// <param name="isUppercase">True if the letter is uppercase.</param>
+        /// <param name="isInjected">True if keystroke was simulated by other software.</param>
         /// <exception cref="T:System.ComponentModel.InvalidEnumArgumentException">
         /// <paramref name="modifiers" /> is not a valid <see cref="T:System.Windows.Input.ModifierKeys" />-or-<paramref name="key" /> is not a valid <see cref="T:System.Windows.Input.Key" />.</exception>
         /// <exception cref="T:System.ArgumentNullException">
         /// <paramref name="displayString" /> is null.</exception>
         /// <exception cref="T:System.NotSupportedException">
         /// <paramref name="key" /> and <paramref name="modifiers" /> do not form a valid <see cref="T:System.Windows.Input.KeyGesture" />.</exception>
-        public SimpleKeyGesture(Key key, ModifierKeys modifiers, string displayString, bool isUppercase = false)
+        public SimpleKeyGesture(Key key, ModifierKeys modifiers, string displayString, bool isUppercase = false, bool isInjected = false)
         {
             if (!IsDefinedKey(key))
                 throw new InvalidEnumArgumentException(nameof(key), (int)key, typeof(Key));
@@ -96,6 +101,7 @@ namespace ScreenToGif.Util
             Modifiers = modifiers;
             Key = key;
             IsUppercase = isUppercase;
+            IsInjected = isInjected;
             DisplayString = displayString ?? throw new ArgumentNullException(nameof(displayString));
         }
 

--- a/ScreenToGif/Util/UserSettings.cs
+++ b/ScreenToGif/Util/UserSettings.cs
@@ -2140,6 +2140,12 @@ namespace ScreenToGif.Util
             set => SetValue(value);
         }
 
+        public bool KeyStrokesIgnoreInjected
+        {
+            get => (bool) GetValue();
+            set => SetValue(value);
+        }
+
         public bool KeyStrokesEarlier
         {
             get => (bool)GetValue();

--- a/ScreenToGif/Windows/Editor.xaml.cs
+++ b/ScreenToGif/Windows/Editor.xaml.cs
@@ -7030,6 +7030,9 @@ namespace ScreenToGif.Windows
                 var keyList = new List<SimpleKeyGesture>();
                 for (var i = 0; i < frame.KeyList.Count; i++)
                 {
+                    if (model.KeyStrokesIgnoreInjected && frame.KeyList[i].IsInjected)
+                        continue;
+
                     //Ignore Control, Shift, Alt and Windows keys if not acting as modifiers.
                     if (model.KeyStrokesIgnoreNonModifiers && (frame.KeyList[i].Key >= Key.LeftShift && frame.KeyList[i].Key <= Key.RightAlt || frame.KeyList[i].Key == Key.LWin || frame.KeyList[i].Key == Key.RWin))
                         continue;

--- a/ScreenToGif/Windows/NewRecorder.xaml.cs
+++ b/ScreenToGif/Windows/NewRecorder.xaml.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Drawing;
 using System.IO;
 using System.Linq;

--- a/ScreenToGif/Windows/NewRecorder.xaml.cs
+++ b/ScreenToGif/Windows/NewRecorder.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Drawing;
 using System.IO;
 using System.Linq;
@@ -577,7 +578,7 @@ namespace ScreenToGif.Windows
             else if (Keyboard.Modifiers.HasFlag(UserSettings.All.FollowModifiers) && e.Key == UserSettings.All.FollowShortcut)
                 UserSettings.All.CursorFollowing = IsFollowing = !IsFollowing;
             else
-                _keyList.Add(new SimpleKeyGesture(e.Key, Keyboard.Modifiers, e.IsUppercase));
+                _keyList.Add(new SimpleKeyGesture(e.Key, Keyboard.Modifiers, e.IsUppercase, e.IsInjected));
         }
 
         /// <summary>

--- a/ScreenToGif/Windows/Recorder.xaml.cs
+++ b/ScreenToGif/Windows/Recorder.xaml.cs
@@ -509,7 +509,7 @@ namespace ScreenToGif.Windows
             else if (Keyboard.Modifiers.HasFlag(UserSettings.All.FollowModifiers) && e.Key == UserSettings.All.FollowShortcut)
                 UserSettings.All.CursorFollowing = IsFollowing = !IsFollowing;
             else
-                _keyList.Add(new SimpleKeyGesture(e.Key, Keyboard.Modifiers, e.IsUppercase));
+                _keyList.Add(new SimpleKeyGesture(e.Key, Keyboard.Modifiers, e.IsUppercase, e.IsInjected));
         }
 
         /// <summary>


### PR DESCRIPTION
# Change in UI
![image](https://user-images.githubusercontent.com/1972649/95006972-bafed780-063c-11eb-8a15-1108afd4f949.png)

# Reason
There are some software tools that will simulate keystrokes to do automatic copy/paste operations or trigger hotkeys.
The user do not need to know what is simuated, what they need to know is the keys presenter inputed on keyboard. 


Thanks.
