### PR TITLE
Fix current time when last frame is selected

### DIFF
--- a/ScreenToGif/Windows/Editor.xaml.cs
+++ b/ScreenToGif/Windows/Editor.xaml.cs
@@ -5815,7 +5815,7 @@ namespace ScreenToGif.Windows
 
         private void UpdateOtherStatistics()
         {
-            if (FrameListView.SelectedIndex > -1 && FrameListView.SelectedIndex < Project.Frames.Count - 1)
+            if (FrameListView.SelectedIndex > -1 && FrameListView.SelectedIndex < Project.Frames.Count)
                 CurrentTime = TimeSpan.FromMilliseconds(Project.Frames.Take(FrameListView.SelectedIndex + 1).Sum(x => x.Delay));
             else
                 CurrentTime = TimeSpan.Zero;


### PR DESCRIPTION
- Addresses issue #760 
- Selecting the last frame will now show the total duration as expected, instead of showing 00:00.00 m

![image](https://user-images.githubusercontent.com/42751540/103234247-2ccd8100-490d-11eb-9056-ce4163ea44e8.png)
