### PR TITLE
Free text tool can now decorate text and add shadow effect

### DIFF
--- a/ScreenToGif/Resources/Localization/StringResources.en.xaml
+++ b/ScreenToGif/Resources/Localization/StringResources.en.xaml
@@ -1170,6 +1170,7 @@
     <s:String x:Key="S.Caption.Layout">Layout</s:String>
     <s:String x:Key="S.Caption.Vertical">Vertical:</s:String>
     <s:String x:Key="S.Caption.Horizontal">Horizontal:</s:String>
+    <s:String x:Key="S.Caption.TextAlignment">Alignment:</s:String>
 
     <!--Editor • Key strokes-->
     <s:String x:Key="S.KeyStrokes">Key Strokes</s:String>
@@ -1522,4 +1523,10 @@
     <!--Orientation-->
     <s:String x:Key="S.Orientation.Horizontal">Horizontal</s:String>
     <s:String x:Key="S.Orientation.Vertical">Vertical</s:String>
+    
+    <!--TextAlignment-->
+    <s:String x:Key="S.TextAlignment.Left">Left</s:String>
+    <s:String x:Key="S.TextAlignment.Right">Right</s:String>
+    <s:String x:Key="S.TextAlignment.Center">Center</s:String>
+    <s:String x:Key="S.TextAlignment.Justify">Justify</s:String>
 </ResourceDictionary>

--- a/ScreenToGif/Resources/Localization/StringResources.en.xaml
+++ b/ScreenToGif/Resources/Localization/StringResources.en.xaml
@@ -1172,6 +1172,8 @@
     <s:String x:Key="S.Caption.Horizontal">Horizontal:</s:String>
     <s:String x:Key="S.Caption.TextAlignment">Alignment:</s:String>
     <s:String x:Key="S.Caption.TextDecoration">Decoration:</s:String>
+    <s:String x:Key="S.Caption.ShadowCollapsed">Shadow (expand to apply)</s:String>
+    <s:String x:Key="S.Caption.ShadowExpanded">Shadow (collapse to remove)</s:String>
 
     <!--Editor • Key strokes-->
     <s:String x:Key="S.KeyStrokes">Key Strokes</s:String>

--- a/ScreenToGif/Resources/Localization/StringResources.en.xaml
+++ b/ScreenToGif/Resources/Localization/StringResources.en.xaml
@@ -1172,8 +1172,6 @@
     <s:String x:Key="S.Caption.Horizontal">Horizontal:</s:String>
     <s:String x:Key="S.Caption.TextAlignment">Alignment:</s:String>
     <s:String x:Key="S.Caption.TextDecoration">Decoration:</s:String>
-    <s:String x:Key="S.Caption.ShadowCollapsed">Shadow (expand to apply)</s:String>
-    <s:String x:Key="S.Caption.ShadowExpanded">Shadow (collapse to remove)</s:String>
 
     <!--Editor • Key strokes-->
     <s:String x:Key="S.KeyStrokes">Key Strokes</s:String>

--- a/ScreenToGif/Resources/Localization/StringResources.en.xaml
+++ b/ScreenToGif/Resources/Localization/StringResources.en.xaml
@@ -1171,6 +1171,7 @@
     <s:String x:Key="S.Caption.Vertical">Vertical:</s:String>
     <s:String x:Key="S.Caption.Horizontal">Horizontal:</s:String>
     <s:String x:Key="S.Caption.TextAlignment">Alignment:</s:String>
+    <s:String x:Key="S.Caption.TextDecoration">Decoration:</s:String>
 
     <!--Editor • Key strokes-->
     <s:String x:Key="S.KeyStrokes">Key Strokes</s:String>
@@ -1529,4 +1530,11 @@
     <s:String x:Key="S.TextAlignment.Right">Right</s:String>
     <s:String x:Key="S.TextAlignment.Center">Center</s:String>
     <s:String x:Key="S.TextAlignment.Justify">Justify</s:String>
+    
+    <!--TextDecoration-->
+    <s:String x:Key="S.TextDecorations.None">None</s:String>
+    <s:String x:Key="S.TextDecorations.Underline">Underline</s:String>
+    <s:String x:Key="S.TextDecorations.Strikethrough">Strikethrough</s:String>
+    <s:String x:Key="S.TextDecorations.OverLine">OverLine</s:String>
+    <s:String x:Key="S.TextDecorations.Baseline">Baseline</s:String>
 </ResourceDictionary>

--- a/ScreenToGif/Resources/Localization/StringResources.pl.xaml
+++ b/ScreenToGif/Resources/Localization/StringResources.pl.xaml
@@ -1098,6 +1098,7 @@
     <s:String x:Key="S.Caption.Layout">Układ</s:String>
     <s:String x:Key="S.Caption.Vertical">Pionowy:</s:String>
     <s:String x:Key="S.Caption.Horizontal">Poziomy:</s:String>
+    <s:String x:Key="S.Caption.TextAlignment">Położenie:</s:String>
 
     <!--Editor • Key strokes-->
     <s:String x:Key="S.KeyStrokes">Uderzenia klawiszy</s:String>
@@ -1436,4 +1437,10 @@
     <!--Orientation-->
     <s:String x:Key="S.Orientation.Horizontal">Poziomo</s:String>
     <s:String x:Key="S.Orientation.Vertical">Pionowo</s:String>
+    
+    <!--TextAlignment-->
+    <s:String x:Key="S.TextAlignment.Left">Do lewej</s:String>
+    <s:String x:Key="S.TextAlignment.Right">Do prawej</s:String>
+    <s:String x:Key="S.TextAlignment.Center">Do środka</s:String>
+    <s:String x:Key="S.TextAlignment.Justify">Wyjustuj</s:String>
 </ResourceDictionary>

--- a/ScreenToGif/Resources/Localization/StringResources.pl.xaml
+++ b/ScreenToGif/Resources/Localization/StringResources.pl.xaml
@@ -1100,7 +1100,9 @@
     <s:String x:Key="S.Caption.Horizontal">Poziomy:</s:String>
     <s:String x:Key="S.Caption.TextAlignment">Położenie:</s:String>
     <s:String x:Key="S.Caption.TextDecoration">Dekoracja:</s:String>
-
+    <s:String x:Key="S.Caption.ShadowCollapsed">Cień (rozwiń aby zastosować)</s:String>
+    <s:String x:Key="S.Caption.ShadowExpanded">Cień (zwiń aby usunąć)</s:String>
+    
     <!--Editor • Key strokes-->
     <s:String x:Key="S.KeyStrokes">Uderzenia klawiszy</s:String>
     <s:String x:Key="S.KeyStrokes.Keys">Klawisze</s:String>

--- a/ScreenToGif/Resources/Localization/StringResources.pl.xaml
+++ b/ScreenToGif/Resources/Localization/StringResources.pl.xaml
@@ -1099,6 +1099,7 @@
     <s:String x:Key="S.Caption.Vertical">Pionowy:</s:String>
     <s:String x:Key="S.Caption.Horizontal">Poziomy:</s:String>
     <s:String x:Key="S.Caption.TextAlignment">Położenie:</s:String>
+    <s:String x:Key="S.Caption.TextDecoration">Dekoracja:</s:String>
 
     <!--Editor • Key strokes-->
     <s:String x:Key="S.KeyStrokes">Uderzenia klawiszy</s:String>
@@ -1443,4 +1444,11 @@
     <s:String x:Key="S.TextAlignment.Right">Do prawej</s:String>
     <s:String x:Key="S.TextAlignment.Center">Do środka</s:String>
     <s:String x:Key="S.TextAlignment.Justify">Wyjustuj</s:String>
+    
+    <!--TextDecoration-->
+    <s:String x:Key="S.TextDecorations.None">Brak</s:String>
+    <s:String x:Key="S.TextDecorations.Underline">Podkreślenie</s:String>
+    <s:String x:Key="S.TextDecorations.Strikethrough">Przekreślenie</s:String>
+    <s:String x:Key="S.TextDecorations.OverLine">Linia nad</s:String>
+    <s:String x:Key="S.TextDecorations.Baseline">Linia bazowa</s:String>
 </ResourceDictionary>

--- a/ScreenToGif/Resources/Localization/StringResources.pl.xaml
+++ b/ScreenToGif/Resources/Localization/StringResources.pl.xaml
@@ -102,7 +102,7 @@
     <s:String x:Key="S.Command.MouseClicks">Kliknięcia myszy</s:String>
     <s:String x:Key="S.Command.Watermark">Wybierz obraz i dodaj jako znak wodny</s:String>
     <s:String x:Key="S.Command.Border">Dodaj obramowanie</s:String>
-    <!--<s:String x:Key="S.Command.Shadow">Add drop shadow</s:String>-->
+    <s:String x:Key="S.Command.Shadow">Dodaj cień</s:String>
     <s:String x:Key="S.Command.Obfuscate">Ukryj wrażliwe elementy na klatkach</s:String>
     <!--<s:String x:Key="S.Command.Cinemagraph">Use the drawing tools to select which parts of the frame should not remain static throughout the animation</s:String>-->
     <!--<s:String x:Key="S.Command.Progress">Progress bar or text with playback details</s:String>-->
@@ -1100,8 +1100,6 @@
     <s:String x:Key="S.Caption.Horizontal">Poziomy:</s:String>
     <s:String x:Key="S.Caption.TextAlignment">Położenie:</s:String>
     <s:String x:Key="S.Caption.TextDecoration">Dekoracja:</s:String>
-    <s:String x:Key="S.Caption.ShadowCollapsed">Cień (rozwiń aby zastosować)</s:String>
-    <s:String x:Key="S.Caption.ShadowExpanded">Cień (zwiń aby usunąć)</s:String>
     
     <!--Editor • Key strokes-->
     <s:String x:Key="S.KeyStrokes">Uderzenia klawiszy</s:String>

--- a/ScreenToGif/Resources/Settings.xaml
+++ b/ScreenToGif/Resources/Settings.xaml
@@ -401,6 +401,7 @@
     <s:Double x:Key="FreeTextFontSize">16.0</s:Double>
     <Color x:Key="FreeTextFontColor">#FF000000</Color>
     <TextAlignment x:Key="FreeTextTextAlignment">Left</TextAlignment>
+    <s:String x:Key="FreeTextTextDecoration">None</s:String>
 
     <!--Editor • Title Frame-->
     <Color x:Key="TitleFrameBackgroundColor">#FFD7D7D7</Color>

--- a/ScreenToGif/Resources/Settings.xaml
+++ b/ScreenToGif/Resources/Settings.xaml
@@ -403,11 +403,10 @@
     <TextAlignment x:Key="FreeTextTextAlignment">Left</TextAlignment>
     <s:String x:Key="FreeTextTextDecoration">None</s:String>
     <s:Boolean x:Key="IsFreeTextShadowGroupExpanded">True</s:Boolean>
-    <s:Boolean x:Key="FreeTextShadowEnabled">False</s:Boolean>
     <Color x:Key="FreeTextShadowColor">#FF000000</Color>
     <s:Double x:Key="FreeTextShadowDirection">315.0</s:Double>
     <s:Double x:Key="FreeTextShadowBlurRadius">5.0</s:Double>
-    <s:Double x:Key="FreeTextShadowOpacity">100.0</s:Double>
+    <s:Double x:Key="FreeTextShadowOpacity">0.0</s:Double>
     <s:Double x:Key="FreeTextShadowDepth">5.0</s:Double>
 
     <!--Editor • Title Frame-->

--- a/ScreenToGif/Resources/Settings.xaml
+++ b/ScreenToGif/Resources/Settings.xaml
@@ -405,7 +405,7 @@
     <s:Boolean x:Key="IsFreeTextShadowGroupExpanded">False</s:Boolean>
     <Color x:Key="FreeTextShadowColor">#FF000000</Color>
     <s:Double x:Key="FreeTextShadowDirection">315.0</s:Double>
-    <s:Double x:Key="FreeTextShadowBlurRadius">5.0</s:Double>
+    <s:Double x:Key="FreeTextShadowBlurRadius">0.0</s:Double>
     <s:Double x:Key="FreeTextShadowOpacity">100.0</s:Double>
     <s:Double x:Key="FreeTextShadowDepth">5.0</s:Double>
 

--- a/ScreenToGif/Resources/Settings.xaml
+++ b/ScreenToGif/Resources/Settings.xaml
@@ -406,7 +406,7 @@
     <s:Boolean x:Key="FreeTextShadowEnabled">False</s:Boolean>
     <Color x:Key="FreeTextShadowColor">#FF000000</Color>
     <s:Double x:Key="FreeTextShadowDirection">315.0</s:Double>
-    <s:Double x:Key="FreeTextShadowBlurRadius">0.0</s:Double>
+    <s:Double x:Key="FreeTextShadowBlurRadius">5.0</s:Double>
     <s:Double x:Key="FreeTextShadowOpacity">100.0</s:Double>
     <s:Double x:Key="FreeTextShadowDepth">5.0</s:Double>
 

--- a/ScreenToGif/Resources/Settings.xaml
+++ b/ScreenToGif/Resources/Settings.xaml
@@ -402,7 +402,8 @@
     <Color x:Key="FreeTextFontColor">#FF000000</Color>
     <TextAlignment x:Key="FreeTextTextAlignment">Left</TextAlignment>
     <s:String x:Key="FreeTextTextDecoration">None</s:String>
-    <s:Boolean x:Key="IsFreeTextShadowGroupExpanded">False</s:Boolean>
+    <s:Boolean x:Key="IsFreeTextShadowGroupExpanded">True</s:Boolean>
+    <s:Boolean x:Key="FreeTextShadowEnabled">False</s:Boolean>
     <Color x:Key="FreeTextShadowColor">#FF000000</Color>
     <s:Double x:Key="FreeTextShadowDirection">315.0</s:Double>
     <s:Double x:Key="FreeTextShadowBlurRadius">0.0</s:Double>

--- a/ScreenToGif/Resources/Settings.xaml
+++ b/ScreenToGif/Resources/Settings.xaml
@@ -400,6 +400,7 @@
     <FontWeight x:Key="FreeTextFontWeight">Normal</FontWeight>
     <s:Double x:Key="FreeTextFontSize">16.0</s:Double>
     <Color x:Key="FreeTextFontColor">#FF000000</Color>
+    <TextAlignment x:Key="FreeTextTextAlignment">Left</TextAlignment>
 
     <!--Editor • Title Frame-->
     <Color x:Key="TitleFrameBackgroundColor">#FFD7D7D7</Color>

--- a/ScreenToGif/Resources/Settings.xaml
+++ b/ScreenToGif/Resources/Settings.xaml
@@ -402,6 +402,12 @@
     <Color x:Key="FreeTextFontColor">#FF000000</Color>
     <TextAlignment x:Key="FreeTextTextAlignment">Left</TextAlignment>
     <s:String x:Key="FreeTextTextDecoration">None</s:String>
+    <s:Boolean x:Key="IsFreeTextShadowGroupExpanded">False</s:Boolean>
+    <Color x:Key="FreeTextShadowColor">#FF000000</Color>
+    <s:Double x:Key="FreeTextShadowDirection">315.0</s:Double>
+    <s:Double x:Key="FreeTextShadowBlurRadius">5.0</s:Double>
+    <s:Double x:Key="FreeTextShadowOpacity">100.0</s:Double>
+    <s:Double x:Key="FreeTextShadowDepth">5.0</s:Double>
 
     <!--Editor • Title Frame-->
     <Color x:Key="TitleFrameBackgroundColor">#FFD7D7D7</Color>

--- a/ScreenToGif/ScreenToGif.csproj
+++ b/ScreenToGif/ScreenToGif.csproj
@@ -349,6 +349,7 @@
       <DependentUpon>MouseClicksPanel.xaml</DependentUpon>
     </Compile>
     <Compile Include="Util\ActionStack.cs" />
+    <Compile Include="Util\Converters\DoubleToBool.cs" />
     <Compile Include="Util\Converters\StringToDoubleArray.cs" />
     <Compile Include="Util\DirectoryHelper.cs" />
     <Compile Include="Util\InputHook\CustomKeyEventArgs.cs" />

--- a/ScreenToGif/Util/Converters/DoubleToBool.cs
+++ b/ScreenToGif/Util/Converters/DoubleToBool.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+
+namespace ScreenToGif.Util.Converters
+{
+    /// <summary>
+    /// Double to Boolean property converter. It compares the the parameter with the provided value.
+    /// </summary>
+    public class DoubleToBool : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            var param = parameter as string;
+
+            if (!(value is double @double) || param == null)
+                return DependencyProperty.UnsetValue;
+
+            return @double == double.Parse(param);
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return DependencyProperty.UnsetValue;
+        }
+    }
+}

--- a/ScreenToGif/Util/UserSettings.cs
+++ b/ScreenToGif/Util/UserSettings.cs
@@ -2335,13 +2335,6 @@ namespace ScreenToGif.Util
             get => (bool)GetValue();
             set => SetValue(value);
         }
-
-        public bool FreeTextShadowEnabled
-        {
-            get => (bool)GetValue();
-            set => SetValue(value);
-        }
-
         public Color FreeTextShadowColor
         {
             get => (Color)GetValue();

--- a/ScreenToGif/Util/UserSettings.cs
+++ b/ScreenToGif/Util/UserSettings.cs
@@ -2336,6 +2336,12 @@ namespace ScreenToGif.Util
             set => SetValue(value);
         }
 
+        public bool FreeTextShadowEnabled
+        {
+            get => (bool)GetValue();
+            set => SetValue(value);
+        }
+
         public Color FreeTextShadowColor
         {
             get => (Color)GetValue();

--- a/ScreenToGif/Util/UserSettings.cs
+++ b/ScreenToGif/Util/UserSettings.cs
@@ -2323,6 +2323,12 @@ namespace ScreenToGif.Util
             get => (TextAlignment)GetValue();
             set => SetValue(value);
         }
+      
+        public string FreeTextTextDecoration
+        {
+            get => (string)GetValue();
+            set => SetValue(value);
+        }
 
         #endregion
 

--- a/ScreenToGif/Util/UserSettings.cs
+++ b/ScreenToGif/Util/UserSettings.cs
@@ -2330,6 +2330,42 @@ namespace ScreenToGif.Util
             set => SetValue(value);
         }
 
+        public bool IsFreeTextShadowGroupExpanded
+        {
+            get => (bool)GetValue();
+            set => SetValue(value);
+        }
+
+        public Color FreeTextShadowColor
+        {
+            get => (Color)GetValue();
+            set => SetValue(value);
+        }
+
+        public double FreeTextShadowDirection
+        {
+            get => (double)GetValue();
+            set => SetValue(value);
+        }
+
+        public double FreeTextShadowBlurRadius
+        {
+            get => (double)GetValue();
+            set => SetValue(value);
+        }
+
+        public double FreeTextShadowOpacity
+        {
+            get => (double)GetValue();
+            set => SetValue(value);
+        }
+
+        public double FreeTextShadowDepth
+        {
+            get => (double)GetValue();
+            set => SetValue(value);
+        }
+
         #endregion
 
         #region Editor • Title Frame

--- a/ScreenToGif/Util/UserSettings.cs
+++ b/ScreenToGif/Util/UserSettings.cs
@@ -2318,6 +2318,12 @@ namespace ScreenToGif.Util
             set => SetValue(value);
         }
 
+        public TextAlignment FreeTextTextAlignment
+        {
+            get => (TextAlignment)GetValue();
+            set => SetValue(value);
+        }
+
         #endregion
 
         #region Editor • Title Frame

--- a/ScreenToGif/Windows/Editor.xaml
+++ b/ScreenToGif/Windows/Editor.xaml
@@ -1427,6 +1427,14 @@
                                    FontWeight="{Binding ElementName=FreeTextFontWeightComboBox, Path=SelectedValue}"
                                    FontSize="{Binding ElementName=FreeTextFontSizeNumericUpDown, Path=Value}"
                                    Foreground="{Binding ElementName=FreeTextFontColorBox, Path=SelectedBrush}">
+                            <TextBlock.Resources>
+                                <DropShadowEffect x:Key="DropShadowEffect" 
+                                                  Color="{Binding Source={x:Static u:UserSettings.All}, Path=FreeTextShadowColor, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}" 
+                                                  BlurRadius="{Binding Source={x:Static u:UserSettings.All}, Path=FreeTextShadowBlurRadius, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}" 
+                                                  Direction="{Binding Source={x:Static u:UserSettings.All}, Path=FreeTextShadowDirection, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}" 
+                                                  Opacity="{Binding Source={x:Static u:UserSettings.All}, Path=FreeTextShadowOpacity, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}" 
+                                                  ShadowDepth="{Binding Source={x:Static u:UserSettings.All}, Path=FreeTextShadowDepth, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}" />
+                            </TextBlock.Resources>
                             <TextBlock.Style>
                                 <Style>
                                     <Style.Triggers>
@@ -1434,10 +1442,14 @@
                                             <Setter Property="TextBlock.TextWrapping" Value="Wrap"/>
                                             <Setter Property="TextBlock.Width" Value="{Binding ElementName=FreeTextWidthNumericUpDown, Path=Value}"/>
                                         </DataTrigger>
+                                        <DataTrigger Binding="{Binding ElementName=IsFreeTextShadowGroupExpanded, Path=IsExpanded}" Value="True">
+                                            <Setter Property="TextBlock.Effect" Value="{StaticResource DropShadowEffect}"/>
+                                        </DataTrigger>
                                     </Style.Triggers>
                                     <Style.Setters>
                                         <Setter Property="TextBlock.TextWrapping" Value="NoWrap"/>
                                         <Setter Property="TextBlock.Width" Value="Auto"/>
+                                        <Setter Property="TextBlock.Effect" Value="{x:Null}"/>
                                     </Style.Setters>
                                 </Style>
                             </TextBlock.Style>
@@ -3256,6 +3268,7 @@
                                 <RowDefinition Height="27"/>
                                 <RowDefinition Height="Auto"/>
                                 <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
                                 <RowDefinition Height="27"/>
                                 <RowDefinition Height="Auto"/>
                             </Grid.RowDefinitions>
@@ -3368,8 +3381,56 @@
                                 </Grid>
                             </Expander>
 
-                            <n:LabelSeparator Grid.Row="3" Text="{DynamicResource S.Caption.Layout}"/>
-                            <Grid Grid.Row="4" Margin="10,0,0,0">
+                            <Expander Grid.Row="3" x:Name="IsFreeTextShadowGroupExpanded" IsExpanded="{Binding IsFreeTextShadowGroupExpanded, Source={x:Static u:UserSettings.All}, Mode=TwoWay}">
+                                <Expander.Style>
+                                    <Style TargetType="Expander" BasedOn="{StaticResource {x:Type Expander}}">
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding ElementName=IsFreeTextShadowGroupExpanded, Path=IsExpanded}" Value="True">
+                                                <Setter Property="Header" Value="{DynamicResource S.Caption.ShadowExpanded}"/>
+                                            </DataTrigger>
+                                            <DataTrigger Binding="{Binding ElementName=IsFreeTextShadowGroupExpanded, Path=IsExpanded}" Value="False">
+                                                <Setter Property="Header" Value="{DynamicResource S.Caption.ShadowCollapsed}"/>
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </Expander.Style>
+                                <Grid Margin="10,0,0,0">
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="Auto"/>
+                                    </Grid.RowDefinitions>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto"/>
+                                        <ColumnDefinition Width="Auto"/>
+                                    </Grid.ColumnDefinitions>
+                                    <Grid.Resources>
+                                        <c:PercentageToOpacity x:Key="PercentageToOpacity"/>
+                                    </Grid.Resources>
+
+                                    <TextBlock Grid.Row="0" Grid.Column="0" Text="{DynamicResource S.Shadow.ShadowColor}" VerticalAlignment="Center" Foreground="{DynamicResource Element.Foreground.Medium}"/>
+                                    <n:ColorBox Grid.Row="0" Grid.Column="1" Margin="10,5" AllowTransparency="False"
+                                            SelectedColor="{Binding Source={x:Static u:UserSettings.All}, Path=FreeTextShadowColor, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+
+                                    <TextBlock Grid.Row="2" Grid.Column="0" Text="{DynamicResource S.Shadow.BlurRadius}" VerticalAlignment="Center" Foreground="{DynamicResource Element.Foreground.Medium}"/>
+                                    <n:DoubleUpDown Grid.Row="2" Grid.Column="1" Minimum="0" Maximum="100" Margin="10,5" StepValue="0.5" Value="{Binding Source={x:Static u:UserSettings.All}, Path=FreeTextShadowBlurRadius, Mode=TwoWay}"/>
+
+                                    <TextBlock Grid.Row="3" Grid.Column="0" Text="{DynamicResource S.Shadow.Direction}" VerticalAlignment="Center" Foreground="{DynamicResource Element.Foreground.Medium}"/>
+                                    <n:DoubleUpDown Grid.Row="3" Grid.Column="1" Minimum="0" Maximum="360" Margin="10,5" StepValue="0.5" Value="{Binding Source={x:Static u:UserSettings.All}, Path=FreeTextShadowDirection, Mode=TwoWay}"/>
+
+                                    <TextBlock Grid.Row="4" Grid.Column="0" Text="{DynamicResource S.Watermark.Opacity}" VerticalAlignment="Center" Foreground="{DynamicResource Element.Foreground.Medium}"/>
+                                    <n:DoubleUpDown Grid.Row="4" Grid.Column="1" Minimum="0" Maximum="100" Margin="10,5" StepValue="0.5" Value="{Binding Source={x:Static u:UserSettings.All}, Path=FreeTextShadowOpacity, Converter={StaticResource PercentageToOpacity}, Mode=TwoWay}"/>
+
+                                    <TextBlock Grid.Row="5" Grid.Column="0" Text="{DynamicResource S.Shadow.Depth}" VerticalAlignment="Center" Foreground="{DynamicResource Element.Foreground.Medium}"/>
+                                    <n:DoubleUpDown Grid.Row="5" Grid.Column="1" Minimum="0" Maximum="100" Margin="10,5" StepValue="0.5" Value="{Binding Source={x:Static u:UserSettings.All}, Path=FreeTextShadowDepth, Mode=TwoWay}"/>
+                                </Grid>
+                            </Expander>
+                            
+                            <n:LabelSeparator Grid.Row="4" Text="{DynamicResource S.Caption.Layout}"/>
+                            <Grid Grid.Row="5" Margin="10,0,0,0">
                                 <Grid.RowDefinitions>
                                     <RowDefinition Height="Auto"/>
                                     <RowDefinition Height="Auto"/>
@@ -3390,7 +3451,7 @@
                                 <n:IntegerUpDown Grid.Row="1" Grid.Column="1" x:Name="FreeTextPositionYNumericUpDown" Margin="10,5" MinWidth="70" 
                                                  Value="{Binding ElementName=FreeTextOverlayControl, Path=Top, Converter={StaticResource DoubleToIntConverter}, Mode=TwoWay, FallbackValue=0}"
                                                  Maximum="{Binding ElementName=FreeTextOverlayControl, Path=ActualHeight, FallbackValue=1000}"/>
-                                
+
                                 <TextBlock Grid.Row="2" Grid.Column="0" Text="{DynamicResource S.Caption.TextAlignment}" VerticalAlignment="Center" Foreground="{DynamicResource Element.Foreground.Medium}"/>
                                 <ComboBox Grid.Row="2" Grid.Column="1" x:Name="FreeTextTextAlignmentComboBox" Margin="10,5" MinWidth="70"
                                               SelectedValuePath="TextAlignment" SelectedValue="{Binding Source={x:Static u:UserSettings.All}, Path=FreeTextTextAlignment, Mode=TwoWay}">

--- a/ScreenToGif/Windows/Editor.xaml
+++ b/ScreenToGif/Windows/Editor.xaml
@@ -3255,7 +3255,6 @@
                                 <RowDefinition Height="27"/>
                                 <RowDefinition Height="Auto"/>
                                 <RowDefinition Height="Auto"/>
-                                <RowDefinition Height="Auto"/>
                                 <RowDefinition Height="27"/>
                                 <RowDefinition Height="Auto"/>
                             </Grid.RowDefinitions>
@@ -3265,34 +3264,7 @@
                                                Text="{Binding Source={x:Static u:UserSettings.All}, Path=FreeTextText, Mode=TwoWay}"
                                                TextChanged="FreeTextTextBox_OnTextChanged"/>
 
-                            <Grid Grid.Row="2" Margin="10,0,0,0">
-                                <Grid.RowDefinitions>
-                                    <RowDefinition Height="Auto"/>
-                                </Grid.RowDefinitions>
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="Auto"/>
-                                    <ColumnDefinition Width="Auto"/>
-                                </Grid.ColumnDefinitions>
-
-                                <TextBlock Grid.Row="0" Grid.Column="0" Text="{DynamicResource S.Caption.TextAlignment}" VerticalAlignment="Center" Foreground="{DynamicResource Element.Foreground.Medium}"/>
-                                <ComboBox Grid.Row="0" Grid.Column="1" x:Name="FreeTextTextAlignmentComboBox" Margin="10,5" MinWidth="100"
-                                              SelectedValuePath="TextAlignment" SelectedValue="{Binding Source={x:Static u:UserSettings.All}, Path=FreeTextTextAlignment, Mode=TwoWay}">
-                                    <ComboBox.ItemTemplate>
-                                        <DataTemplate>
-                                            <VirtualizingStackPanel IsVirtualizing="True" VirtualizationMode="Recycling" ScrollViewer.IsDeferredScrollingEnabled="True">
-                                                <TextBlock FontStyle="{Binding FontStyle}" FontSize="14" Text="{Binding Text}"/>
-                                            </VirtualizingStackPanel>
-                                        </DataTemplate>
-                                    </ComboBox.ItemTemplate>
-
-                                    <TextBlock TextAlignment="Left" Text="{DynamicResource S.TextAlignment.Left}"/>
-                                    <TextBlock TextAlignment="Center" Text="{DynamicResource S.TextAlignment.Center}"/>
-                                    <TextBlock TextAlignment="Right" Text="{DynamicResource S.TextAlignment.Right}"/>
-                                    <TextBlock TextAlignment="Justify" Text="{DynamicResource S.TextAlignment.Justify}"/>
-                                </ComboBox>
-                            </Grid>
-                            
-                            <Expander Grid.Row="3" Header="{DynamicResource S.Caption.Font}" IsExpanded="{Binding IsFreeTextFontGroupExpanded, Source={x:Static u:UserSettings.All}}">
+                            <Expander Grid.Row="2" Header="{DynamicResource S.Caption.Font}" IsExpanded="{Binding IsFreeTextFontGroupExpanded, Source={x:Static u:UserSettings.All}}">
                                 <Grid Margin="10,0,0,0">
                                     <Grid.RowDefinitions>
                                         <RowDefinition Height="Auto"/>
@@ -3376,9 +3348,10 @@
                                 </Grid>
                             </Expander>
 
-                            <n:LabelSeparator Grid.Row="4" Text="{DynamicResource S.Caption.Layout}"/>
-                            <Grid Grid.Row="5" Margin="10,0,0,0">
+                            <n:LabelSeparator Grid.Row="3" Text="{DynamicResource S.Caption.Layout}"/>
+                            <Grid Grid.Row="4" Margin="10,0,0,0">
                                 <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto"/>
                                     <RowDefinition Height="Auto"/>
                                     <RowDefinition Height="Auto"/>
                                     <RowDefinition Height="Auto"/>
@@ -3397,9 +3370,26 @@
                                 <n:IntegerUpDown Grid.Row="1" Grid.Column="1" x:Name="FreeTextPositionYNumericUpDown" Margin="10,5" MinWidth="70" 
                                                  Value="{Binding ElementName=FreeTextOverlayControl, Path=Top, Converter={StaticResource DoubleToIntConverter}, Mode=TwoWay, FallbackValue=0}"
                                                  Maximum="{Binding ElementName=FreeTextOverlayControl, Path=ActualHeight, FallbackValue=1000}"/>
+                                
+                                <TextBlock Grid.Row="2" Grid.Column="0" Text="{DynamicResource S.Caption.TextAlignment}" VerticalAlignment="Center" Foreground="{DynamicResource Element.Foreground.Medium}"/>
+                                <ComboBox Grid.Row="2" Grid.Column="1" x:Name="FreeTextTextAlignmentComboBox" Margin="10,5" MinWidth="70"
+                                              SelectedValuePath="TextAlignment" SelectedValue="{Binding Source={x:Static u:UserSettings.All}, Path=FreeTextTextAlignment, Mode=TwoWay}">
+                                    <ComboBox.ItemTemplate>
+                                        <DataTemplate>
+                                            <VirtualizingStackPanel IsVirtualizing="True" VirtualizationMode="Recycling" ScrollViewer.IsDeferredScrollingEnabled="True">
+                                                <TextBlock FontStyle="{Binding FontStyle}" FontSize="14" Text="{Binding Text}"/>
+                                            </VirtualizingStackPanel>
+                                        </DataTemplate>
+                                    </ComboBox.ItemTemplate>
 
-                                <TextBlock Grid.Row="2" Grid.Column="0" Text="{DynamicResource S.FreeDrawing.Width}" VerticalAlignment="Center" Foreground="{DynamicResource Element.Foreground.Medium}"/>
-                                <n:IntegerUpDown Grid.Row="2" Grid.Column="1" x:Name="FreeTextWidthNumericUpDown" Margin="10,5" MinWidth="70">
+                                    <TextBlock TextAlignment="Left" Text="{DynamicResource S.TextAlignment.Left}"/>
+                                    <TextBlock TextAlignment="Center" Text="{DynamicResource S.TextAlignment.Center}"/>
+                                    <TextBlock TextAlignment="Right" Text="{DynamicResource S.TextAlignment.Right}"/>
+                                    <TextBlock TextAlignment="Justify" Text="{DynamicResource S.TextAlignment.Justify}"/>
+                                </ComboBox>
+
+                                <TextBlock Grid.Row="3" Grid.Column="0" Text="{DynamicResource S.FreeDrawing.Width}" VerticalAlignment="Center" Foreground="{DynamicResource Element.Foreground.Medium}"/>
+                                <n:IntegerUpDown Grid.Row="3" Grid.Column="1" x:Name="FreeTextWidthNumericUpDown" Margin="10,5" MinWidth="70">
                                     <n:IntegerUpDown.Style>
                                         <Style>
                                             <Style.Triggers>

--- a/ScreenToGif/Windows/Editor.xaml
+++ b/ScreenToGif/Windows/Editor.xaml
@@ -1415,16 +1415,32 @@
                     </Grid>
 
                     <n:MoveResizeControl x:Name="FreeTextOverlayControl" VerticalAlignment="Center" HorizontalAlignment="Center" ClipToBounds="True"
-                                         Width="{Binding ElementName=CaptionOverlayGrid, Path=Width, FallbackValue=0}" 
+                                         Width="{Binding ElementName=CaptionOverlayGrid, Path=Width, FallbackValue=0}"
                                          Height="{Binding ElementName=CaptionOverlayGrid, Path=Height, FallbackValue=0}"
                                          Visibility="{Binding ElementName=FreeTextGrid, Path=Visibility}">
                         <TextBlock x:Name="FreeTextTextBlock" Padding="0"
                                    Text="{Binding ElementName=FreeTextTextBox, Path=Text}" 
+                                   TextAlignment="{Binding ElementName=FreeTextTextAlignmentComboBox, Path=SelectedValue}" 
                                    FontFamily="{Binding ElementName=FreeTextFontComboBox, Path=SelectedItem}" 
                                    FontStyle="{Binding ElementName=FreeTextFontStyleComboBox, Path=SelectedValue}"
                                    FontWeight="{Binding ElementName=FreeTextFontWeightComboBox, Path=SelectedValue}"
                                    FontSize="{Binding ElementName=FreeTextFontSizeNumericUpDown, Path=Value}"
-                                   Foreground="{Binding ElementName=FreeTextFontColorBox, Path=SelectedBrush}"/>
+                                   Foreground="{Binding ElementName=FreeTextFontColorBox, Path=SelectedBrush}">
+                            <TextBlock.Style>
+                                <Style>
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding ElementName=FreeTextTextAlignmentComboBox, Path=SelectedValue}" Value="Justify">
+                                            <Setter Property="TextBlock.TextWrapping" Value="Wrap"/>
+                                            <Setter Property="TextBlock.Width" Value="{Binding ElementName=FreeTextWidthNumericUpDown, Path=Value}"/>
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                    <Style.Setters>
+                                        <Setter Property="TextBlock.TextWrapping" Value="NoWrap"/>
+                                        <Setter Property="TextBlock.Width" Value="Auto"/>
+                                    </Style.Setters>
+                                </Style>
+                            </TextBlock.Style>
+                        </TextBlock>
                     </n:MoveResizeControl>
 
                     <Grid x:Name="TitleFrameOverlayGrid" VerticalAlignment="Center" HorizontalAlignment="Center" ClipToBounds="True"
@@ -3239,6 +3255,7 @@
                                 <RowDefinition Height="27"/>
                                 <RowDefinition Height="Auto"/>
                                 <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
                                 <RowDefinition Height="27"/>
                                 <RowDefinition Height="Auto"/>
                             </Grid.RowDefinitions>
@@ -3248,7 +3265,34 @@
                                                Text="{Binding Source={x:Static u:UserSettings.All}, Path=FreeTextText, Mode=TwoWay}"
                                                TextChanged="FreeTextTextBox_OnTextChanged"/>
 
-                            <Expander Grid.Row="2" Header="{DynamicResource S.Caption.Font}" IsExpanded="{Binding IsFreeTextFontGroupExpanded, Source={x:Static u:UserSettings.All}}">
+                            <Grid Grid.Row="2" Margin="10,0,0,0">
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto"/>
+                                </Grid.RowDefinitions>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+
+                                <TextBlock Grid.Row="0" Grid.Column="0" Text="{DynamicResource S.Caption.TextAlignment}" VerticalAlignment="Center" Foreground="{DynamicResource Element.Foreground.Medium}"/>
+                                <ComboBox Grid.Row="0" Grid.Column="1" x:Name="FreeTextTextAlignmentComboBox" Margin="10,5" MinWidth="100"
+                                              SelectedValuePath="TextAlignment" SelectedValue="{Binding Source={x:Static u:UserSettings.All}, Path=FreeTextTextAlignment, Mode=TwoWay}">
+                                    <ComboBox.ItemTemplate>
+                                        <DataTemplate>
+                                            <VirtualizingStackPanel IsVirtualizing="True" VirtualizationMode="Recycling" ScrollViewer.IsDeferredScrollingEnabled="True">
+                                                <TextBlock FontStyle="{Binding FontStyle}" FontSize="14" Text="{Binding Text}"/>
+                                            </VirtualizingStackPanel>
+                                        </DataTemplate>
+                                    </ComboBox.ItemTemplate>
+
+                                    <TextBlock TextAlignment="Left" Text="{DynamicResource S.TextAlignment.Left}"/>
+                                    <TextBlock TextAlignment="Center" Text="{DynamicResource S.TextAlignment.Center}"/>
+                                    <TextBlock TextAlignment="Right" Text="{DynamicResource S.TextAlignment.Right}"/>
+                                    <TextBlock TextAlignment="Justify" Text="{DynamicResource S.TextAlignment.Justify}"/>
+                                </ComboBox>
+                            </Grid>
+                            
+                            <Expander Grid.Row="3" Header="{DynamicResource S.Caption.Font}" IsExpanded="{Binding IsFreeTextFontGroupExpanded, Source={x:Static u:UserSettings.All}}">
                                 <Grid Margin="10,0,0,0">
                                     <Grid.RowDefinitions>
                                         <RowDefinition Height="Auto"/>
@@ -3332,9 +3376,10 @@
                                 </Grid>
                             </Expander>
 
-                            <n:LabelSeparator Grid.Row="3" Text="{DynamicResource S.Caption.Layout}"/>
-                            <Grid Grid.Row="4" Margin="10,0,0,0">
+                            <n:LabelSeparator Grid.Row="4" Text="{DynamicResource S.Caption.Layout}"/>
+                            <Grid Grid.Row="5" Margin="10,0,0,0">
                                 <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto"/>
                                     <RowDefinition Height="Auto"/>
                                     <RowDefinition Height="Auto"/>
                                 </Grid.RowDefinitions>
@@ -3352,6 +3397,24 @@
                                 <n:IntegerUpDown Grid.Row="1" Grid.Column="1" x:Name="FreeTextPositionYNumericUpDown" Margin="10,5" MinWidth="70" 
                                                  Value="{Binding ElementName=FreeTextOverlayControl, Path=Top, Converter={StaticResource DoubleToIntConverter}, Mode=TwoWay, FallbackValue=0}"
                                                  Maximum="{Binding ElementName=FreeTextOverlayControl, Path=ActualHeight, FallbackValue=1000}"/>
+
+                                <TextBlock Grid.Row="2" Grid.Column="0" Text="{DynamicResource S.FreeDrawing.Width}" VerticalAlignment="Center" Foreground="{DynamicResource Element.Foreground.Medium}"/>
+                                <n:IntegerUpDown Grid.Row="2" Grid.Column="1" x:Name="FreeTextWidthNumericUpDown" Margin="10,5" MinWidth="70">
+                                    <n:IntegerUpDown.Style>
+                                        <Style>
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding ElementName=FreeTextTextAlignmentComboBox, Path=SelectedValue}" Value="Justify">
+                                                    <Setter Property="n:IntegerUpDown.IsEnabled" Value="True"/>
+                                                    <Setter Property="n:IntegerUpDown.Value" Value="{Binding ElementName=FreeTextTextBlock, Path=ActualWidth, FallbackValue=0}"/>
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                            <Style.Setters>
+                                                <Setter Property="n:IntegerUpDown.IsEnabled" Value="False"/>
+                                                <Setter Property="n:IntegerUpDown.Value" Value="{Binding ElementName=FreeTextTextBlock, Path=ActualWidth, FallbackValue=0}"/>
+                                            </Style.Setters>
+                                        </Style>
+                                    </n:IntegerUpDown.Style>
+                                </n:IntegerUpDown>
                             </Grid>
                         </Grid>
 

--- a/ScreenToGif/Windows/Editor.xaml
+++ b/ScreenToGif/Windows/Editor.xaml
@@ -1421,6 +1421,7 @@
                         <TextBlock x:Name="FreeTextTextBlock" Padding="0"
                                    Text="{Binding ElementName=FreeTextTextBox, Path=Text}" 
                                    TextAlignment="{Binding ElementName=FreeTextTextAlignmentComboBox, Path=SelectedValue}" 
+                                   TextDecorations="{Binding ElementName=FreeTextTextDecorationComboBox, Path=SelectedValue}"
                                    FontFamily="{Binding ElementName=FreeTextFontComboBox, Path=SelectedItem}" 
                                    FontStyle="{Binding ElementName=FreeTextFontStyleComboBox, Path=SelectedValue}"
                                    FontWeight="{Binding ElementName=FreeTextFontWeightComboBox, Path=SelectedValue}"
@@ -3272,6 +3273,7 @@
                                         <RowDefinition Height="Auto"/>
                                         <RowDefinition Height="Auto"/>
                                         <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="Auto"/>
                                     </Grid.RowDefinitions>
                                     <Grid.ColumnDefinitions>
                                         <ColumnDefinition Width="Auto"/>
@@ -3345,6 +3347,24 @@
                                     <TextBlock Grid.Row="4" Grid.Column="0" Text="{DynamicResource S.Caption.Color}" VerticalAlignment="Center" Foreground="{DynamicResource Element.Foreground.Medium}"/>
                                     <n:ColorBox Grid.Row="4" Grid.Column="1" x:Name="FreeTextFontColorBox" Margin="10,5"
                                                 SelectedColor="{Binding FreeTextFontColor, Source={x:Static u:UserSettings.All}, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+
+                                    <TextBlock Grid.Row="5" Grid.Column="0" Text="{DynamicResource S.Caption.TextDecoration}" VerticalAlignment="Center" Foreground="{DynamicResource Element.Foreground.Medium}"/>
+                                    <ComboBox Grid.Row="5" Grid.Column="1" x:Name="FreeTextTextDecorationComboBox" Margin="10,5" MinWidth="100"
+                                              SelectedValuePath="Tag" SelectedValue="{Binding Source={x:Static u:UserSettings.All}, Path=FreeTextTextDecoration, Mode=TwoWay}">
+                                        <ComboBox.ItemTemplate>
+                                            <DataTemplate>
+                                                <VirtualizingStackPanel IsVirtualizing="True" VirtualizationMode="Recycling" ScrollViewer.IsDeferredScrollingEnabled="True">
+                                                    <TextBlock TextDecorations="{Binding TextDecorations}" FontSize="14" Text="{Binding Text}"/>
+                                                </VirtualizingStackPanel>
+                                            </DataTemplate>
+                                        </ComboBox.ItemTemplate>
+
+                                        <TextBlock TextDecorations="None" Tag="None" Text="{DynamicResource S.TextDecorations.None}"/>
+                                        <TextBlock TextDecorations="Underline" Tag="Underline" Text="{DynamicResource S.TextDecorations.Underline}"/>
+                                        <TextBlock TextDecorations="Strikethrough" Tag="Strikethrough" Text="{DynamicResource S.TextDecorations.Strikethrough}"/>
+                                        <TextBlock TextDecorations="OverLine" Tag="OverLine" Text="{DynamicResource S.TextDecorations.OverLine}"/>
+                                        <TextBlock TextDecorations="Baseline" Tag="Baseline" Text="{DynamicResource S.TextDecorations.Baseline}"/>
+                                    </ComboBox>
                                 </Grid>
                             </Expander>
 

--- a/ScreenToGif/Windows/Editor.xaml
+++ b/ScreenToGif/Windows/Editor.xaml
@@ -1428,6 +1428,7 @@
                                    FontSize="{Binding ElementName=FreeTextFontSizeNumericUpDown, Path=Value}"
                                    Foreground="{Binding ElementName=FreeTextFontColorBox, Path=SelectedBrush}">
                             <TextBlock.Resources>
+                                <c:DoubleToBool x:Key="DoubleToBool"/>
                                 <DropShadowEffect x:Key="DropShadowEffect" 
                                                   Color="{Binding Source={x:Static u:UserSettings.All}, Path=FreeTextShadowColor, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}" 
                                                   BlurRadius="{Binding Source={x:Static u:UserSettings.All}, Path=FreeTextShadowBlurRadius, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}" 
@@ -1442,7 +1443,7 @@
                                             <Setter Property="TextBlock.TextWrapping" Value="Wrap"/>
                                             <Setter Property="TextBlock.Width" Value="{Binding ElementName=FreeTextWidthNumericUpDown, Path=Value}"/>
                                         </DataTrigger>
-                                        <DataTrigger Binding="{Binding Source={x:Static u:UserSettings.All}, Path=FreeTextShadowEnabled, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}" Value="True">
+                                        <DataTrigger Binding="{Binding Source={x:Static u:UserSettings.All}, Path=FreeTextShadowOpacity, Converter={StaticResource DoubleToBool}, ConverterParameter=0, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}" Value="False">
                                             <Setter Property="TextBlock.Effect" Value="{StaticResource DropShadowEffect}"/>
                                         </DataTrigger>
                                     </Style.Triggers>
@@ -3389,7 +3390,6 @@
                                         <RowDefinition Height="Auto"/>
                                         <RowDefinition Height="Auto"/>
                                         <RowDefinition Height="Auto"/>
-                                        <RowDefinition Height="Auto"/>
                                     </Grid.RowDefinitions>
                                     <Grid.ColumnDefinitions>
                                         <ColumnDefinition Width="Auto"/>
@@ -3399,23 +3399,20 @@
                                         <c:PercentageToOpacity x:Key="PercentageToOpacity"/>
                                     </Grid.Resources>
 
-                                    <TextBlock Grid.Row="0" Grid.Column="0" Text="{DynamicResource S.Command.Shadow}" VerticalAlignment="Center" Foreground="{DynamicResource Element.Foreground.Medium}"/>
-                                    <n:ExtendedCheckBox Grid.Row="0" Grid.Column="1" Margin="10,5" IsChecked="{Binding Source={x:Static u:UserSettings.All}, Path=FreeTextShadowEnabled, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+                                    <TextBlock Grid.Row="0" Grid.Column="0" Text="{DynamicResource S.Shadow.ShadowColor}" VerticalAlignment="Center" Foreground="{DynamicResource Element.Foreground.Medium}"/>
+                                    <n:ColorBox Grid.Row="0" Grid.Column="1" Margin="10,5" AllowTransparency="False" SelectedColor="{Binding Source={x:Static u:UserSettings.All}, Path=FreeTextShadowColor, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
 
-                                    <TextBlock Grid.Row="1" Grid.Column="0" Text="{DynamicResource S.Shadow.ShadowColor}" VerticalAlignment="Center" Foreground="{DynamicResource Element.Foreground.Medium}"/>
-                                    <n:ColorBox Grid.Row="1" Grid.Column="1" Margin="10,5" AllowTransparency="False" SelectedColor="{Binding Source={x:Static u:UserSettings.All}, Path=FreeTextShadowColor, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+                                    <TextBlock Grid.Row="1" Grid.Column="0" Text="{DynamicResource S.Shadow.BlurRadius}" VerticalAlignment="Center" Foreground="{DynamicResource Element.Foreground.Medium}"/>
+                                    <n:DoubleUpDown Grid.Row="1" Grid.Column="1" Minimum="0" Maximum="100" Margin="10,5" StepValue="0.5" Value="{Binding Source={x:Static u:UserSettings.All}, Path=FreeTextShadowBlurRadius, Mode=TwoWay}"/>
 
-                                    <TextBlock Grid.Row="2" Grid.Column="0" Text="{DynamicResource S.Shadow.BlurRadius}" VerticalAlignment="Center" Foreground="{DynamicResource Element.Foreground.Medium}"/>
-                                    <n:DoubleUpDown Grid.Row="2" Grid.Column="1" Minimum="0" Maximum="100" Margin="10,5" StepValue="0.5" Value="{Binding Source={x:Static u:UserSettings.All}, Path=FreeTextShadowBlurRadius, Mode=TwoWay}"/>
+                                    <TextBlock Grid.Row="2" Grid.Column="0" Text="{DynamicResource S.Shadow.Direction}" VerticalAlignment="Center" Foreground="{DynamicResource Element.Foreground.Medium}"/>
+                                    <n:DoubleUpDown Grid.Row="2" Grid.Column="1" Minimum="0" Maximum="360" Margin="10,5" StepValue="0.5" Value="{Binding Source={x:Static u:UserSettings.All}, Path=FreeTextShadowDirection, Mode=TwoWay}"/>
 
-                                    <TextBlock Grid.Row="3" Grid.Column="0" Text="{DynamicResource S.Shadow.Direction}" VerticalAlignment="Center" Foreground="{DynamicResource Element.Foreground.Medium}"/>
-                                    <n:DoubleUpDown Grid.Row="3" Grid.Column="1" Minimum="0" Maximum="360" Margin="10,5" StepValue="0.5" Value="{Binding Source={x:Static u:UserSettings.All}, Path=FreeTextShadowDirection, Mode=TwoWay}"/>
+                                    <TextBlock Grid.Row="3" Grid.Column="0" Text="{DynamicResource S.Watermark.Opacity}" VerticalAlignment="Center" Foreground="{DynamicResource Element.Foreground.Medium}"/>
+                                    <n:DoubleUpDown Grid.Row="3" Grid.Column="1" Minimum="0" Maximum="100" Margin="10,5" StepValue="0.5" Value="{Binding Source={x:Static u:UserSettings.All}, Path=FreeTextShadowOpacity, Converter={StaticResource PercentageToOpacity}, Mode=TwoWay}"/>
 
-                                    <TextBlock Grid.Row="4" Grid.Column="0" Text="{DynamicResource S.Watermark.Opacity}" VerticalAlignment="Center" Foreground="{DynamicResource Element.Foreground.Medium}"/>
-                                    <n:DoubleUpDown Grid.Row="4" Grid.Column="1" Minimum="0" Maximum="100" Margin="10,5" StepValue="0.5" Value="{Binding Source={x:Static u:UserSettings.All}, Path=FreeTextShadowOpacity, Converter={StaticResource PercentageToOpacity}, Mode=TwoWay}"/>
-
-                                    <TextBlock Grid.Row="5" Grid.Column="0" Text="{DynamicResource S.Shadow.Depth}" VerticalAlignment="Center" Foreground="{DynamicResource Element.Foreground.Medium}"/>
-                                    <n:DoubleUpDown Grid.Row="5" Grid.Column="1" Minimum="0" Maximum="100" Margin="10,5" StepValue="0.5" Value="{Binding Source={x:Static u:UserSettings.All}, Path=FreeTextShadowDepth, Mode=TwoWay}"/>
+                                    <TextBlock Grid.Row="4" Grid.Column="0" Text="{DynamicResource S.Shadow.Depth}" VerticalAlignment="Center" Foreground="{DynamicResource Element.Foreground.Medium}"/>
+                                    <n:DoubleUpDown Grid.Row="4" Grid.Column="1" Minimum="0" Maximum="100" Margin="10,5" StepValue="0.5" Value="{Binding Source={x:Static u:UserSettings.All}, Path=FreeTextShadowDepth, Mode=TwoWay}"/>
                                 </Grid>
                             </Expander>
                             

--- a/ScreenToGif/Windows/Editor.xaml
+++ b/ScreenToGif/Windows/Editor.xaml
@@ -1442,7 +1442,7 @@
                                             <Setter Property="TextBlock.TextWrapping" Value="Wrap"/>
                                             <Setter Property="TextBlock.Width" Value="{Binding ElementName=FreeTextWidthNumericUpDown, Path=Value}"/>
                                         </DataTrigger>
-                                        <DataTrigger Binding="{Binding ElementName=IsFreeTextShadowGroupExpanded, Path=IsExpanded}" Value="True">
+                                        <DataTrigger Binding="{Binding Source={x:Static u:UserSettings.All}, Path=FreeTextShadowEnabled, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}" Value="True">
                                             <Setter Property="TextBlock.Effect" Value="{StaticResource DropShadowEffect}"/>
                                         </DataTrigger>
                                     </Style.Triggers>
@@ -3381,19 +3381,7 @@
                                 </Grid>
                             </Expander>
 
-                            <Expander Grid.Row="3" x:Name="IsFreeTextShadowGroupExpanded" IsExpanded="{Binding IsFreeTextShadowGroupExpanded, Source={x:Static u:UserSettings.All}, Mode=TwoWay}">
-                                <Expander.Style>
-                                    <Style TargetType="Expander" BasedOn="{StaticResource {x:Type Expander}}">
-                                        <Style.Triggers>
-                                            <DataTrigger Binding="{Binding ElementName=IsFreeTextShadowGroupExpanded, Path=IsExpanded}" Value="True">
-                                                <Setter Property="Header" Value="{DynamicResource S.Caption.ShadowExpanded}"/>
-                                            </DataTrigger>
-                                            <DataTrigger Binding="{Binding ElementName=IsFreeTextShadowGroupExpanded, Path=IsExpanded}" Value="False">
-                                                <Setter Property="Header" Value="{DynamicResource S.Caption.ShadowCollapsed}"/>
-                                            </DataTrigger>
-                                        </Style.Triggers>
-                                    </Style>
-                                </Expander.Style>
+                            <Expander Grid.Row="3" Header="{DynamicResource S.Editor.Image.Shadow}" IsExpanded="{Binding Source={x:Static u:UserSettings.All}, Path=IsFreeTextShadowGroupExpanded, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
                                 <Grid Margin="10,0,0,0">
                                     <Grid.RowDefinitions>
                                         <RowDefinition Height="Auto"/>
@@ -3411,9 +3399,11 @@
                                         <c:PercentageToOpacity x:Key="PercentageToOpacity"/>
                                     </Grid.Resources>
 
-                                    <TextBlock Grid.Row="0" Grid.Column="0" Text="{DynamicResource S.Shadow.ShadowColor}" VerticalAlignment="Center" Foreground="{DynamicResource Element.Foreground.Medium}"/>
-                                    <n:ColorBox Grid.Row="0" Grid.Column="1" Margin="10,5" AllowTransparency="False"
-                                            SelectedColor="{Binding Source={x:Static u:UserSettings.All}, Path=FreeTextShadowColor, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+                                    <TextBlock Grid.Row="0" Grid.Column="0" Text="{DynamicResource S.Command.Shadow}" VerticalAlignment="Center" Foreground="{DynamicResource Element.Foreground.Medium}"/>
+                                    <n:ExtendedCheckBox Grid.Row="0" Grid.Column="1" Margin="10,5" IsChecked="{Binding Source={x:Static u:UserSettings.All}, Path=FreeTextShadowEnabled, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+
+                                    <TextBlock Grid.Row="1" Grid.Column="0" Text="{DynamicResource S.Shadow.ShadowColor}" VerticalAlignment="Center" Foreground="{DynamicResource Element.Foreground.Medium}"/>
+                                    <n:ColorBox Grid.Row="1" Grid.Column="1" Margin="10,5" AllowTransparency="False" SelectedColor="{Binding Source={x:Static u:UserSettings.All}, Path=FreeTextShadowColor, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
 
                                     <TextBlock Grid.Row="2" Grid.Column="0" Text="{DynamicResource S.Shadow.BlurRadius}" VerticalAlignment="Center" Foreground="{DynamicResource Element.Foreground.Medium}"/>
                                     <n:DoubleUpDown Grid.Row="2" Grid.Column="1" Minimum="0" Maximum="100" Margin="10,5" StepValue="0.5" Value="{Binding Source={x:Static u:UserSettings.All}, Path=FreeTextShadowBlurRadius, Mode=TwoWay}"/>


### PR DESCRIPTION
I have added combobox that allows to select from five text decoration options: None, Underline, Strikethrough, OverLine and Baseline. Examples below

![image](https://user-images.githubusercontent.com/1766645/105531639-ec81d880-5ce9-11eb-9738-92999a54183d.png)

There is also possibility to apply text shadow effect in a separate section

![image](https://user-images.githubusercontent.com/1766645/105531803-24891b80-5cea-11eb-9766-b106deae067d.png)
