### PR TITLE
Slow play back fix (#134)

### DIFF
--- a/ScreenToGif/Resources/Localization/StringResources.en.xaml
+++ b/ScreenToGif/Resources/Localization/StringResources.en.xaml
@@ -345,7 +345,9 @@
     <s:String x:Key="S.Options.Editor.General.NotifyWhileClosingEditor">Ask me before closing the Editor (if there's a project opened).</s:String>
     <s:String x:Key="S.Options.Editor.General.TripleClickSelection">Enable triple-click to select the text.</s:String>
     <s:String x:Key="S.Options.Editor.General.DrawOutlineOutside">Draw the outline of captions outside the letters.</s:String>
-    <s:String x:Key="S.Options.Editor.General.SkipFramesDuringPreviewIfBehind">Skip frames during preview if behind time</s:String>
+    <s:String x:Key="S.Options.Editor.General.DropFramesDuringPreviewIfBehind">Drop frames when necessary.</s:String>
+    <s:String x:Key="S.Options.Editor.General.DropFramesDuringPreviewIfBehind.Info">(Skip a frame if the previewer is not able to display it in time)</s:String>
+    <s:String x:Key="S.Options.Editor.General.DropFramesDuringPreviewIfBehind.Tooltip">Skip a frame if the previewer is not able to display it in time.</s:String>
     <s:String x:Key="S.Options.Editor.General.LimitHistory">Impose a limit to the undo/redo history.</s:String>
     <s:String x:Key="S.Options.Editor.General.LimitHistory.Info">(Older actions will be removed when the limit is reached)</s:String>
     <s:String x:Key="S.Options.Editor.General.LimitHistory.Maximum">(Maximum number of actions stored)</s:String>

--- a/ScreenToGif/Resources/Localization/StringResources.en.xaml
+++ b/ScreenToGif/Resources/Localization/StringResources.en.xaml
@@ -345,6 +345,7 @@
     <s:String x:Key="S.Options.Editor.General.NotifyWhileClosingEditor">Ask me before closing the Editor (if there's a project opened).</s:String>
     <s:String x:Key="S.Options.Editor.General.TripleClickSelection">Enable triple-click to select the text.</s:String>
     <s:String x:Key="S.Options.Editor.General.DrawOutlineOutside">Draw the outline of captions outside the letters.</s:String>
+    <s:String x:Key="S.Options.Editor.General.SkipFramesDuringPreviewIfBehind">Skip frames during preview if behind time</s:String>
     <s:String x:Key="S.Options.Editor.General.LimitHistory">Impose a limit to the undo/redo history.</s:String>
     <s:String x:Key="S.Options.Editor.General.LimitHistory.Info">(Older actions will be removed when the limit is reached)</s:String>
     <s:String x:Key="S.Options.Editor.General.LimitHistory.Maximum">(Maximum number of actions stored)</s:String>

--- a/ScreenToGif/Resources/Localization/StringResources.pl.xaml
+++ b/ScreenToGif/Resources/Localization/StringResources.pl.xaml
@@ -306,6 +306,9 @@
     <s:String x:Key="S.Options.Editor.General.NotifyWhileClosingEditor">Potwierdź przed zamknięciem edytora (gdy jest otwarty projekt).</s:String>
     <s:String x:Key="S.Options.Editor.General.TripleClickSelection">Włącz potrójne kliknięcie do zaznaczenia tekstu.</s:String>
     <s:String x:Key="S.Options.Editor.General.DrawOutlineOutside">Rysuj kontur napisów na zewnątrz liter.</s:String>
+    <s:String x:Key="S.Options.Editor.General.DropFramesDuringPreviewIfBehind">Pomiń klatki jeżeli wymagane.</s:String>
+    <s:String x:Key="S.Options.Editor.General.DropFramesDuringPreviewIfBehind.Info">(Pomiń klatkę jeżeli podgląd nie jest w stanie wyświetlić jej na czas)</s:String>
+    <s:String x:Key="S.Options.Editor.General.DropFramesDuringPreviewIfBehind.Tooltip">Pomiń klatkę jeżeli podgląd nie jest w stanie wyświetlić jej na czas.</s:String>
     <!--<s:String x:Key="S.Options.Editor.General.LimitHistory">Impose a limit to the undo/redo history.</s:String>-->
     <!--<s:String x:Key="S.Options.Editor.General.LimitHistory.Info">(Older actions will be removed when the limit is reached)</s:String>-->
     <!--<s:String x:Key="S.Options.Editor.General.LimitHistory.Maximum">(Maximum number of actions stored)</s:String>-->

--- a/ScreenToGif/Resources/Settings.xaml
+++ b/ScreenToGif/Resources/Settings.xaml
@@ -135,7 +135,7 @@
     <s:Boolean x:Key="NotifyWhileClosingEditor">True</s:Boolean>
     <s:Boolean x:Key="TripleClickSelection">False</s:Boolean>
     <s:Boolean x:Key="DrawOutlineOutside">True</s:Boolean>
-    <s:Boolean x:Key="SkipFramesDuringPreviewIfBehind">False</s:Boolean>
+    <s:Boolean x:Key="DropFramesDuringPreviewIfBehind">False</s:Boolean>
     <s:Boolean x:Key="SetHistoryLimit">True</s:Boolean>
     <s:Int32 x:Key="HistoryLimit">50</s:Int32>
     

--- a/ScreenToGif/Resources/Settings.xaml
+++ b/ScreenToGif/Resources/Settings.xaml
@@ -135,6 +135,7 @@
     <s:Boolean x:Key="NotifyWhileClosingEditor">True</s:Boolean>
     <s:Boolean x:Key="TripleClickSelection">False</s:Boolean>
     <s:Boolean x:Key="DrawOutlineOutside">True</s:Boolean>
+    <s:Boolean x:Key="SkipFramesDuringPreviewIfBehind">False</s:Boolean>
     <s:Boolean x:Key="SetHistoryLimit">True</s:Boolean>
     <s:Int32 x:Key="HistoryLimit">50</s:Int32>
     

--- a/ScreenToGif/Util/UserSettings.cs
+++ b/ScreenToGif/Util/UserSettings.cs
@@ -986,7 +986,7 @@ namespace ScreenToGif.Util
             set => SetValue(value);
         }
 
-        public bool SkipFramesDuringPreviewIfBehind
+        public bool DropFramesDuringPreviewIfBehind
         {
             get => (bool)GetValue();
             set => SetValue(value);

--- a/ScreenToGif/Util/UserSettings.cs
+++ b/ScreenToGif/Util/UserSettings.cs
@@ -986,6 +986,12 @@ namespace ScreenToGif.Util
             set => SetValue(value);
         }
 
+        public bool SkipFramesDuringPreviewIfBehind
+        {
+            get => (bool)GetValue();
+            set => SetValue(value);
+        }
+
         public bool SetHistoryLimit
         {
             get => (bool)GetValue();

--- a/ScreenToGif/Windows/Editor.xaml
+++ b/ScreenToGif/Windows/Editor.xaml
@@ -824,16 +824,21 @@
                     <Grid Grid.Column="2" Margin="0,1,0,0">
                         <Grid.RowDefinitions>
                             <RowDefinition/>
+                            <RowDefinition/>
                             <RowDefinition Height="16"/>
                         </Grid.RowDefinitions>
 
-                        <Label Grid.Column="0" Grid.Row="1" Content="{DynamicResource S.Editor.PlaybackOptions.Header}" 
+                        <Label Grid.Column="0" Grid.Row="2" Content="{DynamicResource S.Editor.PlaybackOptions.Header}" 
 							   HorizontalContentAlignment="Center" VerticalContentAlignment="Center" Padding="0" 
 							   FontSize="12" Foreground="{DynamicResource Element.Foreground.Gray112}"/>
 
                         <n:ExtendedCheckBox Grid.Column="0" Grid.Row="0" x:Name="LoopedPlaybackCheckBox" Text="{DynamicResource S.Editor.PlaybackOptions.Loop}" 
                                             IsChecked="{Binding LoopedPlayback, Source={x:Static u:UserSettings.All}, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                             Margin="5,3" ToolTip="{DynamicResource S.Editor.PlaybackOptions.Loop.Info}" ToolTipService.Placement="Bottom" ToolTipService.HorizontalOffset="-5"/>
+
+                        <n:ExtendedCheckBox Grid.Column="0" Grid.Row="1" Text="{DynamicResource S.Options.Editor.General.DropFramesDuringPreviewIfBehind}"
+                                            IsChecked="{Binding DropFramesDuringPreviewIfBehind, Source={x:Static u:UserSettings.All}, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                             Margin="5,3" ToolTip="{DynamicResource S.Options.Editor.General.DropFramesDuringPreviewIfBehind.Tooltip}" ToolTipService.Placement="Bottom" ToolTipService.HorizontalOffset="-5"/>
                     </Grid>
 
                     <Separator Grid.Column="3" Grid.Row="0" Width="1" Height="Auto" Margin="3,2"/>

--- a/ScreenToGif/Windows/Editor.xaml.cs
+++ b/ScreenToGif/Windows/Editor.xaml.cs
@@ -3793,7 +3793,12 @@ namespace ScreenToGif.Windows
                 sw.Restart();
                 long frameDelay = Project.Frames[selectedIndex].Delay;
 
+                // Change active frame
                 Dispatcher.Invoke(() => FrameListView.SelectedIndex = selectedIndex);
+
+                // Wait for application UI to render changes (there is no point in ordering change of next frame if the previous one is not displayed yet)
+                // Loaded priority could be used but input can become laggy
+                Dispatcher.Invoke(() => { }, DispatcherPriority.Background);
 
                 int pass = 0;
                 do
@@ -3818,8 +3823,6 @@ namespace ScreenToGif.Windows
 
                     if (!UserSettings.All.DropFramesDuringPreviewIfBehind)
                     {
-                        // Wait for application UI to render changes
-                        Dispatcher.BeginInvoke(DispatcherPriority.ApplicationIdle, new Action(() => { })).Wait();
                         break;
                     }
 
@@ -3835,6 +3838,7 @@ namespace ScreenToGif.Windows
 
                 if (sw.ElapsedMilliseconds < frameDelay)
                 {
+                    // Wait rest of actual frame delay time
                     System.Threading.SpinWait.SpinUntil(() => sw.ElapsedMilliseconds >= frameDelay);
                 }
             }

--- a/ScreenToGif/Windows/Editor.xaml.cs
+++ b/ScreenToGif/Windows/Editor.xaml.cs
@@ -3816,7 +3816,7 @@ namespace ScreenToGif.Windows
                         selectedIndex++;
                     }
 
-                    if (!UserSettings.All.SkipFramesDuringPreviewIfBehind)
+                    if (!UserSettings.All.DropFramesDuringPreviewIfBehind)
                     {
                         // Wait for application UI to render changes
                         Dispatcher.BeginInvoke(DispatcherPriority.ApplicationIdle, new Action(() => { })).Wait();

--- a/ScreenToGif/Windows/Editor.xaml.cs
+++ b/ScreenToGif/Windows/Editor.xaml.cs
@@ -3805,7 +3805,7 @@ namespace ScreenToGif.Windows
                         //If the playback should not loop, it will stop at the latest frame.
                         if (!UserSettings.All.LoopedPlayback)
                         {
-                            Pause();
+                            Dispatcher.Invoke(() => Pause());
                             return;
                         }
 

--- a/ScreenToGif/Windows/Editor.xaml.cs
+++ b/ScreenToGif/Windows/Editor.xaml.cs
@@ -193,7 +193,7 @@ namespace ScreenToGif.Windows
         /// </summary>
         public bool IsEncoderWindow { get; } = false;
 
-        private readonly System.Windows.Forms.Timer _timerPreview = new System.Windows.Forms.Timer();
+        private System.Threading.CancellationTokenSource _timerPreview;
         private readonly DispatcherTimer _searchTimer;
 
         private Action<object, RoutedEventArgs> _applyAction = null;
@@ -345,7 +345,7 @@ namespace ScreenToGif.Windows
                     RibbonTabControl.UpdateVisual(false);
 
                     //Pauses the recording preview.
-                    if (_timerPreview.Enabled)
+                    if (_timerPreview != null)
                     {
                         WasPreviewing = true;
                         Pause();
@@ -478,7 +478,7 @@ namespace ScreenToGif.Windows
         private void ZoomBoxControl_MouseLeftButtonUp(object sender, MouseButtonEventArgs e)
         {
             //Perhaps ignore when the mouse up happened because of a drag?
-            if (_timerPreview.Enabled || !NotPreviewing)
+            if (_timerPreview != null || !NotPreviewing)
                 (FindResource("Command.Play") as RoutedUICommand)?.Execute(null, this);
         }
 
@@ -560,12 +560,12 @@ namespace ScreenToGif.Windows
 
             #endregion
 
-            if (LastSelected == -1 || _timerPreview.Enabled || WasChangingSelection || LastSelected >= FrameListView.Items.Count || (e.AddedItems.Count > 0 && e.RemovedItems.Count > 0))
+            if (LastSelected == -1 || _timerPreview != null || WasChangingSelection || LastSelected >= FrameListView.Items.Count || (e.AddedItems.Count > 0 && e.RemovedItems.Count > 0))
                 LastSelected = FrameListView.SelectedIndex;
 
             FrameListBoxItem current;
 
-            if (_timerPreview.Enabled || WasChangingSelection)
+            if (_timerPreview != null || WasChangingSelection)
             {
                 current = FrameListView.Items[FrameListView.SelectedIndex] as FrameListBoxItem;
             }
@@ -595,7 +595,7 @@ namespace ScreenToGif.Windows
 
             if (current != null)
             {
-                if (!current.IsFocused && !_timerPreview.Enabled)// && !WasChangingSelection)
+                if (!current.IsFocused && _timerPreview == null)// && !WasChangingSelection)
                     current.Focus();
 
                 var currentIndex = FrameListView.Items.IndexOf(current);
@@ -607,7 +607,7 @@ namespace ScreenToGif.Windows
                 }
             }
 
-            if (!_timerPreview.Enabled)
+            if (_timerPreview == null)
                 UpdateOtherStatistics();
 
             WasChangingSelection = false;
@@ -3784,32 +3784,60 @@ namespace ScreenToGif.Windows
 
         #endregion
 
-        private void TimerPreview_Tick(object sender, EventArgs e)
+        private void TimerPreview_Tick(int selectedIndex)
         {
-            _timerPreview.Tick -= TimerPreview_Tick;
+            var sw = new Stopwatch();
 
-            if (Project.Frames.Count - 1 == FrameListView.SelectedIndex)
+            while (_timerPreview != null && !_timerPreview.IsCancellationRequested)
             {
-                //If the playback should not loop, it will stop at the latest frame.
-                if (!UserSettings.All.LoopedPlayback)
+                sw.Restart();
+                long frameDelay = Project.Frames[selectedIndex].Delay;
+
+                Dispatcher.Invoke(() => FrameListView.SelectedIndex = selectedIndex);
+
+                int pass = 0;
+                do
                 {
-                    Pause();
-                    return;
+                    pass++;
+
+                    if (Project.Frames.Count - 1 == selectedIndex)
+                    {
+                        //If the playback should not loop, it will stop at the latest frame.
+                        if (!UserSettings.All.LoopedPlayback)
+                        {
+                            Pause();
+                            return;
+                        }
+
+                        selectedIndex = 0;
+                    }
+                    else
+                    {
+                        selectedIndex++;
+                    }
+
+                    if (!UserSettings.All.SkipFramesDuringPreviewIfBehind)
+                    {
+                        // Wait for application UI to render changes
+                        Dispatcher.BeginInvoke(DispatcherPriority.ApplicationIdle, new Action(() => { })).Wait();
+                        break;
+                    }
+
+                    if (pass >= 2)
+                    {
+                        frameDelay += Project.Frames[selectedIndex].Delay;
+                    }
                 }
+                while (sw.ElapsedMilliseconds >= frameDelay);
 
-                FrameListView.SelectedIndex = 0;
+                if (Project.Frames[selectedIndex].Delay == 0)
+                    Project.Frames[selectedIndex].Delay = 10;
+
+                if (sw.ElapsedMilliseconds < frameDelay)
+                {
+                    System.Threading.SpinWait.SpinUntil(() => sw.ElapsedMilliseconds >= frameDelay);
+                }
             }
-            else
-                FrameListView.SelectedIndex++;
-
-            if (Project.Frames[FrameListView.SelectedIndex].Delay == 0)
-                Project.Frames[FrameListView.SelectedIndex].Delay = 10;
-
-            //Sets the interval for this frame. If this frame has 500ms, the next frame will take 500ms to show.
-            _timerPreview.Interval = Project.Frames[FrameListView.SelectedIndex].Delay;
-            _timerPreview.Tick += TimerPreview_Tick;
-
-            GC.Collect(2);
         }
 
         private void Control_DragEnter(object sender, DragEventArgs e)
@@ -4980,10 +5008,14 @@ namespace ScreenToGif.Windows
         {
             lock (UserSettings.Lock)
             {
-                if (_timerPreview.Enabled || !NotPreviewing)
+                if (_timerPreview != null || !NotPreviewing)
                 {
-                    _timerPreview.Tick -= TimerPreview_Tick;
-                    _timerPreview.Stop();
+                    if (_timerPreview != null)
+                    {
+                        _timerPreview.Cancel();
+                        _timerPreview.Dispose();
+                        _timerPreview = null;
+                    }
 
                     NotPreviewing = true;
                     PlayButton.Text = LocalizationHelper.Get("S.Editor.Playback.Play");
@@ -5018,20 +5050,25 @@ namespace ScreenToGif.Windows
                     if (Project.Frames[FrameListView.SelectedIndex].Delay == 0)
                         Project.Frames[FrameListView.SelectedIndex].Delay = 10;
 
-                    _timerPreview.Interval = Project.Frames[FrameListView.SelectedIndex].Delay;
-                    _timerPreview.Tick += TimerPreview_Tick;
-                    _timerPreview.Start();
+                    _timerPreview = new System.Threading.CancellationTokenSource();
+                    int selectedIndex = FrameListView.SelectedIndex;
+
+                    Task.Run(() => TimerPreview_Tick(selectedIndex), _timerPreview.Token);
                 }
             }
         }
 
         private void Pause()
         {
-            if (!_timerPreview.Enabled && NotPreviewing)
+            if (_timerPreview == null && NotPreviewing)
                 return;
 
-            _timerPreview.Tick -= TimerPreview_Tick;
-            _timerPreview.Stop();
+            if (_timerPreview != null)
+            {
+                _timerPreview.Cancel();
+                _timerPreview.Dispose();
+                _timerPreview = null;
+            }
 
             NotPreviewing = true;
             PlayButton.Text = LocalizationHelper.Get("S.Editor.Playback.Play");

--- a/ScreenToGif/Windows/Options.xaml
+++ b/ScreenToGif/Windows/Options.xaml
@@ -1037,7 +1037,8 @@
                                 <n:ExtendedCheckBox Text="{DynamicResource S.Options.Editor.General.NotifyWhileClosingEditor}" Margin="0,3" IsChecked="{Binding Path=NotifyWhileClosingEditor, Mode=TwoWay}"/>
                                 <n:ExtendedCheckBox Text="{DynamicResource S.Options.Editor.General.TripleClickSelection}" Margin="0,3" IsChecked="{Binding Path=TripleClickSelection, Mode=TwoWay}"/>
                                 <n:ExtendedCheckBox Text="{DynamicResource S.Options.Editor.General.DrawOutlineOutside}" Margin="0,3" IsChecked="{Binding Path=DrawOutlineOutside, Mode=TwoWay}"/>
-                                <n:ExtendedCheckBox Text="{DynamicResource S.Options.Editor.General.SkipFramesDuringPreviewIfBehind}" Margin="0,3" IsChecked="{Binding Path=SkipFramesDuringPreviewIfBehind, Mode=TwoWay}"/>
+                                <n:ExtendedCheckBox Text="{DynamicResource S.Options.Editor.General.DropFramesDuringPreviewIfBehind}" Margin="0,3" IsChecked="{Binding Path=DropFramesDuringPreviewIfBehind, Mode=TwoWay}"
+                                                    Info="{DynamicResource S.Options.Editor.General.DropFramesDuringPreviewIfBehind.Info}"/>
 
                                 <n:ExtendedCheckBox Text="{DynamicResource S.Options.Editor.General.LimitHistory}" Margin="0,3" VerticalAlignment="Top" IsChecked="{Binding Path=SetHistoryLimit, Mode=TwoWay}"
                                                     Info="{DynamicResource S.Options.Editor.General.LimitHistory.Info}"/>

--- a/ScreenToGif/Windows/Options.xaml
+++ b/ScreenToGif/Windows/Options.xaml
@@ -1037,6 +1037,7 @@
                                 <n:ExtendedCheckBox Text="{DynamicResource S.Options.Editor.General.NotifyWhileClosingEditor}" Margin="0,3" IsChecked="{Binding Path=NotifyWhileClosingEditor, Mode=TwoWay}"/>
                                 <n:ExtendedCheckBox Text="{DynamicResource S.Options.Editor.General.TripleClickSelection}" Margin="0,3" IsChecked="{Binding Path=TripleClickSelection, Mode=TwoWay}"/>
                                 <n:ExtendedCheckBox Text="{DynamicResource S.Options.Editor.General.DrawOutlineOutside}" Margin="0,3" IsChecked="{Binding Path=DrawOutlineOutside, Mode=TwoWay}"/>
+                                <n:ExtendedCheckBox Text="{DynamicResource S.Options.Editor.General.SkipFramesDuringPreviewIfBehind}" Margin="0,3" IsChecked="{Binding Path=SkipFramesDuringPreviewIfBehind, Mode=TwoWay}"/>
 
                                 <n:ExtendedCheckBox Text="{DynamicResource S.Options.Editor.General.LimitHistory}" Margin="0,3" VerticalAlignment="Top" IsChecked="{Binding Path=SetHistoryLimit, Mode=TwoWay}"
                                                     Info="{DynamicResource S.Options.Editor.General.LimitHistory.Info}"/>


### PR DESCRIPTION
Preview playback has few problems.

1. It uses System.Windows.Forms.Timer which has resolution about 16 ms and its multiples.
2. Processing time of bitmap and displaying it on UI was not taken into account.

First means that if frame delay is 20 ms it will be shown not earlier than after 32 ms. Second means that loading image, attaching it to UI control and refreshing whole interface is effectively pausing timer interval.

I have implemented two changes.

1. Got rid of System.Windows.Forms.Timer and replaced it with dedicated task executed by thread from domain thread pool when play command is invoked.
2. Added option to skip frames while during preview if behind schedule.

On example project with 96 frames in 720p and 10 ms of delay per every frame average time (for 10 passes) of play from first to last frame for original code was **5,2s**. After changing timer to dedicated thread time dropped to **3,3s**. After checking option to drop frames behind I have got **0,98s** for 96 * 10 ms = 960 ms as target time.

I did add this option to editor settings
![image](https://user-images.githubusercontent.com/1766645/111915878-a0001280-8a78-11eb-8537-cc74c24e0b03.png)
but now I see that there is probably more appropriate place here
![image](https://user-images.githubusercontent.com/1766645/111915907-c8880c80-8a78-11eb-979a-7ad65dab2193.png)