### PR TITLE
Fix selection of frames after Delete all next/prev command

### DIFF
--- a/ScreenToGif/Windows/Editor.xaml.cs
+++ b/ScreenToGif/Windows/Editor.xaml.cs
@@ -1619,7 +1619,7 @@ namespace ScreenToGif.Windows
                 DeleteFrame(index);
 
             AdjustFrameNumbers(0);
-            SelectNear(0);
+            FrameListView.ScrollIntoView(0);
 
             Project.Persist();
             UpdateStatistics();
@@ -1647,8 +1647,8 @@ namespace ScreenToGif.Windows
             //From the end to the start.
             for (var i = countList; i > lastFrame; i--)
                 DeleteFrame(i);
-            
-            SelectNear(lastFrame - 1);
+
+            FrameListView.ScrollIntoView(FrameListView.SelectedItem);
 
             Project.Persist();
             UpdateStatistics();


### PR DESCRIPTION
This small PR fixes the selection issue after Delete all next/previous commands. Before, for the "Delete all next" command range selection was cleared and only one frame was selected even if a range selection was before. 

Currently, it will keep the original selection as it was before executing the command. Apparently whats only needed was a call to `FrameListView.ScrollIntoView` to move the list to the visible frame. The whole `SelectNear` was not really doing any good for the range selection.

Before (only one frame selected after command executes):
![s2g_before](https://user-images.githubusercontent.com/1296768/116811166-15670480-ab48-11eb-8b38-bbe422aa753d.gif)


After (range selection kept):
![s2g_after](https://user-images.githubusercontent.com/1296768/116811169-1ac44f00-ab48-11eb-88c8-2e8d3ed8e0d7.gif)


Change in, "Delete All Previous" is done for consistency, it was working as expected even with `SelectNear(0)`. I guess it was selecting already selected frame and not canceling range selection.