### PR TITLE
Preview Playback: Ensure that latest frame will be shown if "drops frames behind" is enabled

### DIFF
--- a/ScreenToGif/Windows/Editor.xaml.cs
+++ b/ScreenToGif/Windows/Editor.xaml.cs
@@ -3083,6 +3083,10 @@ namespace ScreenToGif.Windows
                             //If the playback should not loop, it will stop at the latest frame.
                             if (!UserSettings.All.LoopedPlayback)
                             {
+                                // This will ensure that latest frame will be shown if drops frames behind is enabled
+                                if (UserSettings.All.DropFramesDuringPreviewIfBehind && pass > 1)
+                                    break;
+
                                 Dispatcher.Invoke(Pause);
                                 return;
                             }


### PR DESCRIPTION
It is small continuation of previous pull request #810 which added support for dropping frames while preview play. It introduces consistency in preview play behavior.

When "Loop during playback" option is unchecked then play display every frame from currently selected up to last frame. But if "Drop frames when necessary" is also check then last frame will not always be selected and shown on end of preview play. This fix resolves this situation introducing consistency in behavior and ensuring that last frame is always shown when play ends.