### PR TITLE
Preview Playback: Speeds up by nearly 50%

### DIFF
--- a/ScreenToGif/Windows/Editor.xaml
+++ b/ScreenToGif/Windows/Editor.xaml
@@ -3999,9 +3999,22 @@
                                     <ColumnDefinition/>
                                 </Grid.ColumnDefinitions>
 
-                                <Image Grid.Row="0" Grid.Column="0" Grid.RowSpan="2" x:Name="TransitionImage" 
-                                       Source="{Binding ElementName=ZoomBoxControl, Path=ImageSource, Converter={StaticResource UriToBitmapConverter}}" Stretch="Uniform"
-                                       Effect="{StaticResource Shadow.Border.Large}"/>
+                                <Image Grid.Row="0" Grid.Column="0" Grid.RowSpan="2" x:Name="TransitionImage"
+                                       Source="{Binding Path=ImageSource, Converter={StaticResource UriToBitmapConverter}}" Stretch="Uniform"
+                                       Effect="{StaticResource Shadow.Border.Large}">
+                                    <Image.Style>
+                                        <Style TargetType="FrameworkElement">
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding ElementName=FadeGrid, Path=Visibility}" Value="Visible">
+                                                    <Setter Property="DataContext" Value="{Binding ElementName=ZoomBoxControl}"/>
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                            <Style.Setters>
+                                                <Setter Property="DataContext" Value="{x:Null}"/>
+                                            </Style.Setters>
+                                        </Style>
+                                    </Image.Style>
+                                </Image>
 
                                 <TextBlock Grid.Row="0" Grid.Column="1" Text="{Binding ElementName=FadeSlider, Path=Value, StringFormat='{} {0}x'}" 
                                            FontSize="16" Padding="2,0" Foreground="{DynamicResource Element.Foreground.Detail}" VerticalAlignment="Center"/>
@@ -4068,9 +4081,22 @@
                                     <ColumnDefinition/>
                                 </Grid.ColumnDefinitions>
 
-                                <Image Grid.Row="0" Grid.Column="0" Grid.RowSpan="2" x:Name="TransitionImage2" 
-                                       Source="{Binding ElementName=ZoomBoxControl, Path=ImageSource, Converter={StaticResource UriToBitmapConverter}}" Stretch="Uniform"
-                                       Effect="{StaticResource Shadow.Border.Large}"/>
+                                <Image Grid.Row="0" Grid.Column="0" Grid.RowSpan="2" x:Name="TransitionImage2"
+                                       Source="{Binding Path=ImageSource, Converter={StaticResource UriToBitmapConverter}}" Stretch="Uniform"
+                                       Effect="{StaticResource Shadow.Border.Large}">
+                                    <Image.Style>
+                                        <Style TargetType="FrameworkElement">
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding ElementName=SlideGrid, Path=Visibility}" Value="Visible">
+                                                    <Setter Property="DataContext" Value="{Binding ElementName=ZoomBoxControl}"/>
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                            <Style.Setters>
+                                                <Setter Property="DataContext" Value="{x:Null}"/>
+                                            </Style.Setters>
+                                        </Style>
+                                    </Image.Style>
+                                </Image>
 
                                 <TextBlock Grid.Row="0" Grid.Column="1" Text="{Binding ElementName=SlideSlider, Path=Value, StringFormat='{} {0}x'}" 
                                            FontSize="16" Padding="2,0" Foreground="{DynamicResource Element.Foreground.Detail}" VerticalAlignment="Center"/>

--- a/ScreenToGif/Windows/Editor.xaml.cs
+++ b/ScreenToGif/Windows/Editor.xaml.cs
@@ -227,7 +227,10 @@ namespace ScreenToGif.Windows
         public Editor()
         {
             InitializeComponent();
-            
+
+            // Hide last displayed panel after the panel closing animation is complete.
+            this.FindStoryboard("HideOverlayGridStoryboard").Completed += HideLastDisplayedPanel;
+
             #region Adjust the position
 
             //Tries to adjust the position/size of the window, centers on screen otherwise.
@@ -4732,6 +4735,11 @@ namespace ScreenToGif.Windows
             ShapeDrawingCanvas.DeselectAll();
         }
 
+        private void HideLastDisplayedPanel(object sender, EventArgs e)
+        {
+            HideAllVisibleGrids();
+        }
+
         private void ClosePanel(bool isCancel = false, bool removeEvent = false)
         {
             StatusList.Remove(StatusType.Warning);
@@ -4749,8 +4757,6 @@ namespace ScreenToGif.Windows
 
             BeginStoryboard(this.FindStoryboard("HidePanelStoryboard"), HandoffBehavior.Compose);
             BeginStoryboard(this.FindStoryboard("HideOverlayGridStoryboard"), HandoffBehavior.Compose);
-
-            HideAllVisibleGrids();
         }
 
         private List<int> SelectedFramesIndex()

--- a/ScreenToGif/Windows/Editor.xaml.cs
+++ b/ScreenToGif/Windows/Editor.xaml.cs
@@ -4435,17 +4435,7 @@ namespace ScreenToGif.Windows
         {
             var focusFirstVisibleChild = true;
 
-            #region Hide all visible grids
-
-            foreach (var child in ActionInternalGrid.Children.OfType<Grid>().Where(x => x.Visibility == Visibility.Visible))
-                child.Visibility = Visibility.Collapsed;
-
-            CustomContentControl.Content = null;
-            CustomContentControl.Visibility = Visibility.Collapsed;
-
-            ShapeDrawingCanvas.DeselectAll();
-
-            #endregion
+            HideAllVisibleGrids();
 
             #region Overlay
 
@@ -4730,7 +4720,18 @@ namespace ScreenToGif.Windows
 
             CommandManager.InvalidateRequerySuggested();
         }
-        
+
+        private void HideAllVisibleGrids()
+        {
+            foreach (var child in ActionInternalGrid.Children.OfType<Grid>().Where(x => x.Visibility == Visibility.Visible))
+                child.Visibility = Visibility.Collapsed;
+
+            CustomContentControl.Content = null;
+            CustomContentControl.Visibility = Visibility.Collapsed;
+
+            ShapeDrawingCanvas.DeselectAll();
+        }
+
         private void ClosePanel(bool isCancel = false, bool removeEvent = false)
         {
             StatusList.Remove(StatusType.Warning);
@@ -4749,8 +4750,7 @@ namespace ScreenToGif.Windows
             BeginStoryboard(this.FindStoryboard("HidePanelStoryboard"), HandoffBehavior.Compose);
             BeginStoryboard(this.FindStoryboard("HideOverlayGridStoryboard"), HandoffBehavior.Compose);
 
-            CustomContentControl.Content = null;
-            CustomContentControl.Visibility = Visibility.Collapsed;
+            HideAllVisibleGrids();
         }
 
         private List<int> SelectedFramesIndex()


### PR DESCRIPTION
I have noticed that two other image controls (fade and slide effects preview) are bonded to the same image control which is used by preview play to display frames in a way that evaluates theirs bindings during playback. I have changed this by adding a condition for effect panel visibility.

In result preview playback works now roughly...**50% faster**. No kidding :-)

My pull request consists of two commits.

1. First one "Do not update fade and slide effects preview images when not shown" is essential for this speed boost. It makes these bindings being applied through effects panel visibility condition.
2. Second one "Change panel visibility to hidden after close of right panel" well...it extends code that is already there (which change visibility of last shown panel just before showing next panel) to do the same thing just after cancel or close of effects panel. **Purpose of this commit is to maintain conditional binding - without it after applying fade or slide effect additional bindings will still evaluate (unnecessarily) until some other panel is shown (and visibility of last opened will be change to hidden)**.
It is not clear to me why this was not happening so far. I thought that this can be intentional because of process of applying effects after closing the panel. That is why I mention it and bring it to your attention. I have tested some effect apply functionality (I mean fade and slide) and it seems to work. But this second commit touches probably every available effect. So I ask here what do you think about it? @NickeManarin 

Both commits are independent of each other.