### PR TITLE
Fix exception when pressing cancel while inserting frames is ongoing

### DIFF
--- a/ScreenToGif/Windows/Other/Insert.xaml
+++ b/ScreenToGif/Windows/Other/Insert.xaml
@@ -261,7 +261,7 @@
             <n:ExtendedButton x:Name="OkButton" Grid.Column="2" Text="{DynamicResource S.Ok}" Padding="5,0" MinWidth="90" Margin="5" 
                               ContentWidth="18" ContentHeight="18" Icon="{StaticResource Vector.Ok}" Click="OkButton_Click"/>
             <n:ExtendedButton x:Name="CancelButton" Grid.Column="3" Text="{DynamicResource S.Cancel}" Padding="5,0" MinWidth="90" Margin="5" 
-                              ContentWidth="18" ContentHeight="18" Icon="{StaticResource Vector.Cancel}" IsCancel="True" Click="CancelButton_Click"/>
+                              ContentWidth="18" ContentHeight="18" Icon="{StaticResource Vector.Cancel}" Click="CancelButton_Click"/>
         </Grid>
     </Grid>
 </Window>


### PR DESCRIPTION
When testing #882 I've noticed that there is possibility to can close an ongoing import process, but when doing so, exception occurs. The problem is in `DialogResult` being set when it supposed to be not.

Steps to repro:
1. open gif animation
2. insert image before frame 0
3. while the process is ongoing press cancel
 
![image](https://user-images.githubusercontent.com/1296768/117513396-e01c4580-af91-11eb-9c7b-9cd9b146294a.png)

The problem was that `DialogResult` was set in code but also `CancelButton` had `IsCancel` property set to `true`. With that property it means `DialogResult` is set automatically and actually already getting out of `ShowDialog()` even the code is still running in the handlers . Removed `IsCancel` property and allowed the code to set `DialogResult` and close the window when needed. 