### PR TITLE
Removed _applyAction check from Playback CanExecute

### DIFF
--- a/ScreenToGif/Windows/Editor.xaml.cs
+++ b/ScreenToGif/Windows/Editor.xaml.cs
@@ -1459,7 +1459,7 @@ namespace ScreenToGif.Windows
 
         private void Playback_CanExecute(object sender, CanExecuteRoutedEventArgs e)
         {
-            e.CanExecute = Project != null && Project.Frames.Count > 1 && !IsLoading && _applyAction == null;
+            e.CanExecute = Project != null && Project.Frames.Count > 1 && !IsLoading;
         }
 
         private void FirstFrame_Executed(object sender, ExecutedRoutedEventArgs e)


### PR DESCRIPTION
Removed `_applyAction` check from `Playback_CanExecute` as it seems not be needed for correct behavior of the app. Did the testing and didn't observe any unwanted behavior w/o this check.

Fix #881 