### PR TITLE
Allow to set different colors for clicks

### DIFF
--- a/ScreenToGif/Controls/BaseScreenRecorder.cs
+++ b/ScreenToGif/Controls/BaseScreenRecorder.cs
@@ -23,7 +23,7 @@ namespace ScreenToGif.Controls
         /// <summary>
         /// Indicates when the user is mouse-clicking.
         /// </summary>
-        internal bool RecordClicked = false;
+        internal MouseButtonType RecordClicked = MouseButtonType.None;
 
         /// <summary>
         /// Deals with all screen capture methods.

--- a/ScreenToGif/Model/FrameInfo.cs
+++ b/ScreenToGif/Model/FrameInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+using System;
+using System.Collections.Generic;
 using System.Drawing;
 using System.Runtime.Serialization;
 using System.Windows;
@@ -45,11 +46,11 @@ namespace ScreenToGif.Model
         /// <summary>
         /// Initialises a FrameInfo instance.
         /// </summary>
-        /// <param name="clicked">True if the user clicked with the mouse.</param>
+        /// <param name="button">Type of mouse button clicked with the mouse.</param>
         /// <param name="keyList">The list of pressed keys.</param>
-        public FrameInfo(bool clicked, List<SimpleKeyGesture> keyList)
+        public FrameInfo(MouseButtonType button, List<SimpleKeyGesture> keyList)
         {
-            WasClicked = clicked;
+            ButtonClicked = button;
             KeyList = keyList != null ? new List<SimpleKeyGesture>(keyList) : new List<SimpleKeyGesture>();
         }
 
@@ -58,12 +59,12 @@ namespace ScreenToGif.Model
         /// </summary>
         /// <param name="path">The Bitmap.</param>
         /// <param name="delay">The delay.</param>
-        /// <param name="clicked">True if the user clicked with the mouse.</param>
+        /// <param name="button">Type of mouse button the user clicked with the mouse.</param>
         /// <param name="keyList">The list of pressed keys.</param>
         /// <param name="index">The index of the frame.</param>
-        public FrameInfo(string path, int delay, bool clicked, List<SimpleKeyGesture> keyList = null, int index = 0) : this(path, delay)
+        public FrameInfo(string path, int delay, MouseButtonType button, List<SimpleKeyGesture> keyList = null, int index = 0) : this(path, delay)
         {
-            WasClicked = clicked;
+            ButtonClicked = button;
             KeyList = keyList != null ? new List<SimpleKeyGesture>(keyList) : new List<SimpleKeyGesture>();
             Index = index;
         }
@@ -74,15 +75,15 @@ namespace ScreenToGif.Model
         /// <param name="path">The Bitmap.</param>
         /// <param name="delay">The delay.</param>
         /// <param name="cursorX">Cursor X position.</param>
-        /// <param name="cursorY">Cursor Y positiob</param>
-        /// <param name="clicked">True if the user clicked with the mouse.</param>
+        /// <param name="cursorY">Cursor Y position</param>
+        /// <param name="button">Type of mouse button user clicked with the mouse.</param>
         /// <param name="keyList">The list of pressed keys.</param>
         /// <param name="index">The index of the frame.</param>
-        public FrameInfo(string path, int delay, int cursorX, int cursorY, bool clicked, List<SimpleKeyGesture> keyList = null, int index = 0) : this(path, delay)
+        public FrameInfo(string path, int delay, int cursorX, int cursorY, MouseButtonType button, List<SimpleKeyGesture> keyList = null, int index = 0) : this(path, delay)
         {
             CursorX = cursorX;
             CursorY = cursorY;
-            WasClicked = clicked;
+            ButtonClicked = button;
             KeyList = keyList != null ? new List<SimpleKeyGesture>(keyList) : new List<SimpleKeyGesture>();
             Index = index;
         }
@@ -128,9 +129,15 @@ namespace ScreenToGif.Model
         public int CursorY { get; set; } = int.MinValue;
 
         /// <summary>
-        /// True if was clicked.
+        /// Type of the button that was clicked.
         /// </summary>
-        [DataMember(EmitDefaultValue = false, Name = "Clicked")]
+        [DataMember(EmitDefaultValue = false, Name = "ButtonClicked")]
+        public MouseButtonType ButtonClicked { get; set; }
+
+        /// <summary>
+        /// If the button was clicked (legacy projects)
+        /// </summary>
+        [DataMember(Name = "Clicked")]
         public bool WasClicked { get; set; }
 
         /// <summary>
@@ -190,6 +197,19 @@ namespace ScreenToGif.Model
         [IgnoreDataMember]
         public Image Image { get; set; }
 
+
+        /// <summary>
+        /// This works as a migration method for mouse clicks. Before storing the button
+        /// type only bool was stored to mark the clicks. During opening old project it will
+        /// be converted to Left mouse button click loosing some info unfortunately.
+        /// </summary>
+        /// <param name="context"></param>
+        [OnDeserialized]
+        void MigrateData(StreamingContext context)
+        {
+            if (ButtonClicked == MouseButtonType.None)
+                ButtonClicked = WasClicked ? MouseButtonType.Left : MouseButtonType.None;
+        }
         #endregion
     }
 }

--- a/ScreenToGif/Model/MouseClicksModel.cs
+++ b/ScreenToGif/Model/MouseClicksModel.cs
@@ -6,7 +6,9 @@ namespace ScreenToGif.Model
 {
     public class MouseClicksModel : DefaultTaskModel
     {
-        private Color _foregroundColor;
+        private Color _leftButtonForegroundColor;
+        private Color _rightButtonForegroundColor;
+        private Color _middleButtonForegroundColor;
         private double _width;
         private double _height;
 
@@ -15,10 +17,22 @@ namespace ScreenToGif.Model
             TaskType = TaskTypeEnum.MouseClicks;
         }
 
-        public Color ForegroundColor
+        public Color LeftButtonForegroundColor
         {
-            get => _foregroundColor;
-            set => SetProperty(ref _foregroundColor, value);
+            get => _leftButtonForegroundColor;
+            set => SetProperty(ref _leftButtonForegroundColor, value);
+        }
+
+        public Color RightButtonForegroundColor
+        {
+            get => _rightButtonForegroundColor;
+            set => SetProperty(ref _rightButtonForegroundColor, value);
+        }
+
+        public Color MiddleButtonForegroundColor
+        {
+            get => _middleButtonForegroundColor;
+            set => SetProperty(ref _middleButtonForegroundColor, value);
         }
 
         public double Width
@@ -35,14 +49,19 @@ namespace ScreenToGif.Model
 
         public override string ToString()
         {
-            return $"{LocalizationHelper.Get("S.Caption.Color")} #{ForegroundColor.A:X2}{ForegroundColor.R:X2}{ForegroundColor.G:X2}{ForegroundColor.B:X2}, {LocalizationHelper.Get("S.FreeDrawing.Width")} {Width}, {LocalizationHelper.Get("S.FreeDrawing.Height")} {Height}";
+            return $"{LocalizationHelper.Get("S.Caption.LeftButton.Color")} #{LeftButtonForegroundColor.A:X2}{LeftButtonForegroundColor.R:X2}{LeftButtonForegroundColor.G:X2}{LeftButtonForegroundColor.B:X2}, "+
+                   $"{LocalizationHelper.Get("S.Caption.MiddleButton.Color")} #{MiddleButtonForegroundColor.A:X2}{MiddleButtonForegroundColor.R:X2}{MiddleButtonForegroundColor.G:X2}{MiddleButtonForegroundColor.B:X2}, "+
+                   $"{LocalizationHelper.Get("S.Caption.RightButton.Color")} #{RightButtonForegroundColor.A:X2}{RightButtonForegroundColor.R:X2}{RightButtonForegroundColor.G:X2}{RightButtonForegroundColor.B:X2}, "+
+                   $"{LocalizationHelper.Get("S.FreeDrawing.Width")} {Width}, {LocalizationHelper.Get("S.FreeDrawing.Height")} {Height}";
         }
 
         public static MouseClicksModel Default()
         {
             return new MouseClicksModel
             {
-                ForegroundColor = Color.FromArgb(120, 255, 255, 0),
+                LeftButtonForegroundColor = Color.FromArgb(120, 255, 255, 0),
+                RightButtonForegroundColor = Color.FromArgb(120, 255, 0, 0),
+                MiddleButtonForegroundColor = Color.FromArgb(120, 0, 255,255),
                 Height = 12,
                 Width = 12
             };
@@ -52,7 +71,9 @@ namespace ScreenToGif.Model
         {
             return new MouseClicksModel
             {
-                ForegroundColor = UserSettings.All.MouseClicksColor,
+                LeftButtonForegroundColor = UserSettings.All.LeftMouseButtonClicksColor,
+                MiddleButtonForegroundColor = UserSettings.All.MiddleMouseButtonClicksColor,
+                RightButtonForegroundColor = UserSettings.All.RightMouseButtonClicksColor,
                 Height = UserSettings.All.MouseClicksHeight,
                 Width = UserSettings.All.MouseClicksWidth
             };

--- a/ScreenToGif/Resources/Localization/StringResources.en.xaml
+++ b/ScreenToGif/Resources/Localization/StringResources.en.xaml
@@ -1297,6 +1297,9 @@
     <s:String x:Key="S.Caption.Horizontal">Horizontal:</s:String>
     <s:String x:Key="S.Caption.TextAlignment">Alignment:</s:String>
     <s:String x:Key="S.Caption.TextDecoration">Decoration:</s:String>
+    <s:String x:Key="S.Caption.LeftButton.Color">Left button color:</s:String>
+    <s:String x:Key="S.Caption.MiddleButton.Color">Middle button color:</s:String>
+    <s:String x:Key="S.Caption.RightButton.Color">Right button color:</s:String>
 
     <!--Editor • Key strokes-->
     <s:String x:Key="S.KeyStrokes">Key Strokes</s:String>

--- a/ScreenToGif/Resources/Localization/StringResources.pl.xaml
+++ b/ScreenToGif/Resources/Localization/StringResources.pl.xaml
@@ -1103,6 +1103,9 @@
     <s:String x:Key="S.Caption.Horizontal">Poziomy:</s:String>
     <s:String x:Key="S.Caption.TextAlignment">Położenie:</s:String>
     <s:String x:Key="S.Caption.TextDecoration">Dekoracja:</s:String>
+    <s:String x:Key="S.Caption.LeftButton.Color">Kolor dla lewego przycisku:</s:String>
+    <s:String x:Key="S.Caption.MiddleButton.Color">Kolor dla środkowego przycisku:</s:String>
+    <s:String x:Key="S.Caption.RightButton.Color">Kolor dla prawego przycisku:</s:String>
     
     <!--Editor • Key strokes-->
     <s:String x:Key="S.KeyStrokes">Wciśnięcia klawiszy</s:String>

--- a/ScreenToGif/Resources/Settings.xaml
+++ b/ScreenToGif/Resources/Settings.xaml
@@ -141,7 +141,7 @@
     
     <!--Options • Automated Tasks-->
     <c:ArrayList Capacity="1" x:Key="AutomatedTasksList">
-        <m:MouseClicksModel ForegroundColor="#78FFFF00" Width="12" Height="12" TaskType="MouseClicks"/>
+        <m:MouseClicksModel LeftButtonForegroundColor="#78FFFF00" RightButtonForegroundColor="#78FF0000" MiddleButtonForegroundColor="#7800FFFF" Width="12" Height="12" TaskType="MouseClicks"/>
     </c:ArrayList>
 
     <!--Options • Shortcuts-->
@@ -337,7 +337,9 @@
     <Orientation x:Key="ProgressOrientation">Horizontal</Orientation>
 
     <!--Editor • Mouse Clicks-->
-    <Color x:Key="MouseClicksColor">#78FFFF00</Color>
+    <Color x:Key="LeftMouseButtonClicksColor">#78FFFF00</Color>
+    <Color x:Key="MiddleMouseButtonClicksColor">#7800FFFF</Color>
+    <Color x:Key="RightMouseButtonClicksColor">#78FF0000</Color>
     <s:Double x:Key="MouseClicksWidth">12</s:Double>
     <s:Double x:Key="MouseClicksHeight">12</s:Double>
     

--- a/ScreenToGif/ScreenToGif.csproj
+++ b/ScreenToGif/ScreenToGif.csproj
@@ -548,6 +548,7 @@
     <Compile Include="Model\UpdateAvailable.cs" />
     <Compile Include="Util\InterProcessChannel\InstanceSwitcherChannel.cs" />
     <Compile Include="Util\InterProcessChannel\SettingsPersistenceChannel.cs" />
+    <Compile Include="Util\MouseButtonType.cs" />
     <Compile Include="Util\MutexList.cs" />
     <Compile Include="Util\NotificationManager.cs" />
     <Compile Include="Capture\ImageCapture.cs" />

--- a/ScreenToGif/Settings/UserSettings.cs
+++ b/ScreenToGif/Settings/UserSettings.cs
@@ -2470,7 +2470,19 @@ namespace ScreenToGif.Settings
 
         #region Editor • Mouse Clicks
 
-        public Color MouseClicksColor
+        public Color LeftMouseButtonClicksColor
+        {
+            get => (Color)GetValue();
+            set => SetValue(value);
+        }
+
+        public Color RightMouseButtonClicksColor
+        {
+            get => (Color)GetValue();
+            set => SetValue(value);
+        }
+
+        public Color MiddleMouseButtonClicksColor
         {
             get => (Color)GetValue();
             set => SetValue(value);

--- a/ScreenToGif/UserControls/MouseClicksPanel.xaml
+++ b/ScreenToGif/UserControls/MouseClicksPanel.xaml
@@ -18,6 +18,8 @@
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
             </Grid.RowDefinitions>
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto"/>
@@ -25,15 +27,21 @@
                 <ColumnDefinition Width="*"/>
             </Grid.ColumnDefinitions>
 
-            <TextBlock Grid.Row="0" Grid.Column="0" Text="{DynamicResource S.Caption.Color}" VerticalAlignment="Center" Foreground="{DynamicResource Element.Foreground.Medium}"/>
-            <n:ColorBox Grid.Row="0" Grid.Column="1" SelectedColor="{Binding ForegroundColor, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Margin="10,5"/>
+            <TextBlock Grid.Row="0" Grid.Column="0" Text="{DynamicResource S.Caption.LeftButton.Color}" VerticalAlignment="Center" Foreground="{DynamicResource Element.Foreground.Medium}"/>
+            <n:ColorBox Grid.Row="0" Grid.Column="1" SelectedColor="{Binding LeftButtonForegroundColor, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Margin="10,5"/>
 
-            <TextBlock Grid.Row="1" Grid.Column="0" Text="{DynamicResource S.FreeDrawing.Width}" VerticalAlignment="Center" Foreground="{DynamicResource Element.Foreground.Medium}"/>
-            <n:DoubleUpDown Grid.Row="1" Grid.Column="1" x:Name="ClickWidthDoubleUpDown" Minimum="1" Maximum="1000" Margin="10,5" MinWidth="70" 
+            <TextBlock Grid.Row="1" Grid.Column="0" Text="{DynamicResource S.Caption.MiddleButton.Color}" VerticalAlignment="Center" Foreground="{DynamicResource Element.Foreground.Medium}"/>
+            <n:ColorBox Grid.Row="1" Grid.Column="1" SelectedColor="{Binding MiddleButtonForegroundColor, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Margin="10,5"/>
+
+            <TextBlock Grid.Row="2" Grid.Column="0" Text="{DynamicResource S.Caption.RightButton.Color}" VerticalAlignment="Center" Foreground="{DynamicResource Element.Foreground.Medium}"/>
+            <n:ColorBox Grid.Row="2" Grid.Column="1" SelectedColor="{Binding RightButtonForegroundColor, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Margin="10,5"/>
+
+            <TextBlock Grid.Row="3" Grid.Column="0" Text="{DynamicResource S.FreeDrawing.Width}" VerticalAlignment="Center" Foreground="{DynamicResource Element.Foreground.Medium}"/>
+            <n:DoubleUpDown Grid.Row="3" Grid.Column="1" x:Name="ClickWidthDoubleUpDown" Minimum="1" Maximum="1000" Margin="10,5" MinWidth="70"
                             Value="{Binding Width, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
 
-            <TextBlock Grid.Row="2" Grid.Column="0" Text="{DynamicResource S.FreeDrawing.Height}" VerticalAlignment="Center" Foreground="{DynamicResource Element.Foreground.Medium}"/>
-            <n:DoubleUpDown Grid.Row="2" Grid.Column="1" x:Name="ClickHeightDoubleUpDown" Minimum="1" Maximum="1000" Margin="10,5" MinWidth="70"
+            <TextBlock Grid.Row="4" Grid.Column="0" Text="{DynamicResource S.FreeDrawing.Height}" VerticalAlignment="Center" Foreground="{DynamicResource Element.Foreground.Medium}"/>
+            <n:DoubleUpDown Grid.Row="4" Grid.Column="1" x:Name="ClickHeightDoubleUpDown" Minimum="1" Maximum="1000" Margin="10,5" MinWidth="70"
                             Value="{Binding Height, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
         </Grid>
     </Grid>

--- a/ScreenToGif/Util/ActionStack.cs
+++ b/ScreenToGif/Util/ActionStack.cs
@@ -71,7 +71,7 @@ namespace ScreenToGif.Util
                         //Copy to a folder.
                         File.Copy(frame.Path, savedFrame);
 
-                        savedFrames.Add(new FrameInfo(savedFrame, frame.Delay, frame.CursorX, frame.CursorY, frame.WasClicked, frame.KeyList, frame.Index));
+                        savedFrames.Add(new FrameInfo(savedFrame, frame.Delay, frame.CursorX, frame.CursorY, frame.ButtonClicked, frame.KeyList, frame.Index));
                     }
 
                     //Create a StageChange object with the saved frames and push to the undo stack.
@@ -95,7 +95,7 @@ namespace ScreenToGif.Util
                         //Copy to a folder.
                         File.Copy(frame.Path, savedFrame);
 
-                        savedFrames.Add(new FrameInfo(savedFrame, frame.Delay, frame.CursorX, frame.CursorY, frame.WasClicked, frame.KeyList, frame.Index));
+                        savedFrames.Add(new FrameInfo(savedFrame, frame.Delay, frame.CursorX, frame.CursorY, frame.ButtonClicked, frame.KeyList, frame.Index));
                     }
 
                     //Create a StageChange object with the saved frames and push to the undo stack.
@@ -115,7 +115,7 @@ namespace ScreenToGif.Util
                     {
                         var frame = frames[position];
 
-                        savedFrames.Add(new FrameInfo(frame.Path, frame.Delay, frame.CursorX, frame.CursorY, frame.WasClicked, frame.KeyList, frame.Index));
+                        savedFrames.Add(new FrameInfo(frame.Path, frame.Delay, frame.CursorX, frame.CursorY, frame.ButtonClicked, frame.KeyList, frame.Index));
                     }
 
                     //Create a StageChange object with the saved frames and push to the undo stack.
@@ -157,7 +157,7 @@ namespace ScreenToGif.Util
                 //Copy to a folder.
                 File.Copy(frame.Path, savedFrame);
 
-                savedFrames.Add(new FrameInfo(savedFrame, frame.Delay, frame.CursorX, frame.CursorY, frame.WasClicked, frame.KeyList, frame.Index));
+                savedFrames.Add(new FrameInfo(savedFrame, frame.Delay, frame.CursorX, frame.CursorY, frame.ButtonClicked, frame.KeyList, frame.Index));
             }
 
             #endregion
@@ -169,7 +169,7 @@ namespace ScreenToGif.Util
             {
                 var frame = frames[position];
 
-                savedFrames.Add(new FrameInfo(frame.Path, frame.Delay, frame.CursorX, frame.CursorY, frame.WasClicked, frame.KeyList, frame.Index));
+                savedFrames.Add(new FrameInfo(frame.Path, frame.Delay, frame.CursorX, frame.CursorY, frame.ButtonClicked, frame.KeyList, frame.Index));
             }
 
             #endregion
@@ -283,7 +283,7 @@ namespace ScreenToGif.Util
                             //Copy to a folder.
                             File.Copy(frame.Path, savedFrame);
 
-                            savedFrames.Add(new FrameInfo(savedFrame, frame.Delay, frame.CursorX, frame.CursorY, frame.WasClicked, frame.KeyList, frame.Index));
+                            savedFrames.Add(new FrameInfo(savedFrame, frame.Delay, frame.CursorX, frame.CursorY, frame.ButtonClicked, frame.KeyList, frame.Index));
                         }
 
                         redoStateChange.Frames = savedFrames;
@@ -310,7 +310,7 @@ namespace ScreenToGif.Util
                             //Copy to a folder.
                             File.Copy(frame.Path, savedFrame);
 
-                            savedFrames2.Add(new FrameInfo(savedFrame, frame.Delay, frame.CursorX, frame.CursorY, frame.WasClicked, frame.KeyList, frame.Index));
+                            savedFrames2.Add(new FrameInfo(savedFrame, frame.Delay, frame.CursorX, frame.CursorY, frame.ButtonClicked, frame.KeyList, frame.Index));
                         }
 
                         redoStateChange.Frames = savedFrames2;
@@ -373,14 +373,14 @@ namespace ScreenToGif.Util
                             //Copy to a folder.
                             File.Copy(frame.Path, savedFrame);
 
-                            savedFrames3.Add(new FrameInfo(savedFrame, frame.Delay, frame.CursorX, frame.CursorY, frame.WasClicked, frame.KeyList, frame.Index));
+                            savedFrames3.Add(new FrameInfo(savedFrame, frame.Delay, frame.CursorX, frame.CursorY, frame.ButtonClicked, frame.KeyList, frame.Index));
                         }
 
                         //Saves the altered frames, without saving the images.
                         foreach (var position in latestUndo.Indexes2)
                         {
                             var frame = current[position];
-                            savedFrames3.Add(new FrameInfo(frame.Path, frame.Delay, frame.CursorX, frame.CursorY, frame.WasClicked, frame.KeyList, frame.Index));
+                            savedFrames3.Add(new FrameInfo(frame.Path, frame.Delay, frame.CursorX, frame.CursorY, frame.ButtonClicked, frame.KeyList, frame.Index));
                         }
 
                         redoStateChange.Frames = savedFrames3;
@@ -418,7 +418,7 @@ namespace ScreenToGif.Util
                         File.Copy(frame.Path, file);
 
                         //Add to list.
-                        current.Insert(index, new FrameInfo(file, frame.Delay, frame.CursorX, frame.CursorY, frame.WasClicked, frame.KeyList, frame.Index));
+                        current.Insert(index, new FrameInfo(file, frame.Delay, frame.CursorX, frame.CursorY, frame.ButtonClicked, frame.KeyList, frame.Index));
 
                         currentIndex++;
                     }
@@ -442,7 +442,7 @@ namespace ScreenToGif.Util
                         //Get the current frame before or after returning the properties values?
                         var currentFrame = current[latestUndo.Indexes[alteredIndex2]];
 
-                        current[latestUndo.Indexes[alteredIndex2]] = new FrameInfo(currentFrame.Path, frame.Delay, frame.CursorX, frame.CursorY, frame.WasClicked, frame.KeyList, frame.Index); //Image location stays the same.
+                        current[latestUndo.Indexes[alteredIndex2]] = new FrameInfo(currentFrame.Path, frame.Delay, frame.CursorX, frame.CursorY, frame.ButtonClicked, frame.KeyList, frame.Index); //Image location stays the same.
 
                         //Copy file to folder.
                         File.Copy(frame.Path, currentFrame.Path, true);
@@ -466,7 +466,7 @@ namespace ScreenToGif.Util
                     var alteredIndex = 0;
                     foreach (var frame in latestUndo.Frames)
                     {
-                        current[latestUndo.Indexes[alteredIndex]] = new FrameInfo(frame.Path, frame.Delay, frame.CursorX, frame.CursorY, frame.WasClicked, frame.KeyList, frame.Index);
+                        current[latestUndo.Indexes[alteredIndex]] = new FrameInfo(frame.Path, frame.Delay, frame.CursorX, frame.CursorY, frame.ButtonClicked, frame.KeyList, frame.Index);
 
                         alteredIndex++;
                     }
@@ -536,7 +536,7 @@ namespace ScreenToGif.Util
                         File.Copy(frame.Path, file);
 
                         //Add to list.
-                        current.Insert(index, new FrameInfo(file, frame.Delay, frame.CursorX, frame.CursorY, frame.WasClicked, frame.KeyList, frame.Index));
+                        current.Insert(index, new FrameInfo(file, frame.Delay, frame.CursorX, frame.CursorY, frame.ButtonClicked, frame.KeyList, frame.Index));
 
                         currentIndex2++;
                     }
@@ -551,7 +551,7 @@ namespace ScreenToGif.Util
                     var alteredIndex3 = 0;
                     foreach (var frame in latestUndo.Frames.Skip(latestUndo.Indexes.Count))
                     {
-                        current[latestUndo.Indexes2[alteredIndex3]] = new FrameInfo(frame.Path, frame.Delay, frame.CursorX, frame.CursorY, frame.WasClicked, frame.KeyList, frame.Index);
+                        current[latestUndo.Indexes2[alteredIndex3]] = new FrameInfo(frame.Path, frame.Delay, frame.CursorX, frame.CursorY, frame.ButtonClicked, frame.KeyList, frame.Index);
 
                         alteredIndex3++;
                     }
@@ -610,7 +610,7 @@ namespace ScreenToGif.Util
                         //Copy to a folder.
                         File.Copy(frame.Path, savedFrame);
 
-                        savedFrames.Add(new FrameInfo(savedFrame, frame.Delay, frame.CursorX, frame.CursorY, frame.WasClicked, frame.KeyList, frame.Index));
+                        savedFrames.Add(new FrameInfo(savedFrame, frame.Delay, frame.CursorX, frame.CursorY, frame.ButtonClicked, frame.KeyList, frame.Index));
                     }
 
                     undoStateChange.Frames = savedFrames;
@@ -637,7 +637,7 @@ namespace ScreenToGif.Util
                         //Copy to a folder.
                         File.Copy(frame.Path, savedFrame);
 
-                        savedFrames2.Add(new FrameInfo(savedFrame, frame.Delay, frame.CursorX, frame.CursorY, frame.WasClicked, frame.KeyList, frame.Index));
+                        savedFrames2.Add(new FrameInfo(savedFrame, frame.Delay, frame.CursorX, frame.CursorY, frame.ButtonClicked, frame.KeyList, frame.Index));
                     }
 
                     undoStateChange.Frames = savedFrames2;
@@ -702,14 +702,14 @@ namespace ScreenToGif.Util
                         //Copy to a folder.
                         File.Copy(frame.Path, savedFrame);
 
-                        savedFrames3.Add(new FrameInfo(savedFrame, frame.Delay, frame.CursorX, frame.CursorY, frame.WasClicked, frame.KeyList, frame.Index));
+                        savedFrames3.Add(new FrameInfo(savedFrame, frame.Delay, frame.CursorX, frame.CursorY, frame.ButtonClicked, frame.KeyList, frame.Index));
                     }
 
                     //Saves the altered frames, without saving the images.
                     foreach (var position in latestRedo.Indexes2)
                     {
                         var frame = current[position];
-                        savedFrames3.Add(new FrameInfo(frame.Path, frame.Delay, frame.CursorX, frame.CursorY, frame.WasClicked, frame.KeyList, frame.Index));
+                        savedFrames3.Add(new FrameInfo(frame.Path, frame.Delay, frame.CursorX, frame.CursorY, frame.ButtonClicked, frame.KeyList, frame.Index));
                     }
 
                     undoStateChange.Frames = savedFrames3;
@@ -746,7 +746,7 @@ namespace ScreenToGif.Util
                         File.Copy(frame.Path, file);
 
                         //Add to list.
-                        current.Insert(index, new FrameInfo(file, frame.Delay, frame.CursorX, frame.CursorY, frame.WasClicked, frame.KeyList, frame.Index));
+                        current.Insert(index, new FrameInfo(file, frame.Delay, frame.CursorX, frame.CursorY, frame.ButtonClicked, frame.KeyList, frame.Index));
 
                         currentIndex++;
                     }
@@ -790,7 +790,7 @@ namespace ScreenToGif.Util
                     var alteredIndex = 0;
                     foreach (var frame in latestRedo.Frames)
                     {
-                        current[latestRedo.Indexes[alteredIndex]] = new FrameInfo(frame.Path, frame.Delay, frame.CursorX, frame.CursorY, frame.WasClicked, frame.KeyList, frame.Index);
+                        current[latestRedo.Indexes[alteredIndex]] = new FrameInfo(frame.Path, frame.Delay, frame.CursorX, frame.CursorY, frame.ButtonClicked, frame.KeyList, frame.Index);
 
                         alteredIndex++;
                     }
@@ -861,7 +861,7 @@ namespace ScreenToGif.Util
                         File.Copy(frame.Path, file);
 
                         //Add to list.
-                        current.Insert(index, new FrameInfo(file, frame.Delay, frame.CursorX, frame.CursorY, frame.WasClicked, frame.KeyList, frame.Index));
+                        current.Insert(index, new FrameInfo(file, frame.Delay, frame.CursorX, frame.CursorY, frame.ButtonClicked, frame.KeyList, frame.Index));
 
                         currentIndex2++;
                     }
@@ -876,7 +876,7 @@ namespace ScreenToGif.Util
                     var alteredIndex3 = 0;
                     foreach (var frame in latestRedo.Frames.Skip(latestRedo.Indexes.Count))
                     {
-                        current[latestRedo.Indexes2[alteredIndex3]] = new FrameInfo(frame.Path, frame.Delay, frame.CursorX, frame.CursorY, frame.WasClicked, frame.KeyList, frame.Index);
+                        current[latestRedo.Indexes2[alteredIndex3]] = new FrameInfo(frame.Path, frame.Delay, frame.CursorX, frame.CursorY, frame.ButtonClicked, frame.KeyList, frame.Index);
 
                         alteredIndex3++;
                     }

--- a/ScreenToGif/Util/ClipBoard.cs
+++ b/ScreenToGif/Util/ClipBoard.cs
@@ -41,7 +41,7 @@ namespace ScreenToGif.Util
                     File.Copy(frameInfo.Path, filename, true);
 
                     //Create the new object and add to the list.
-                    newList.Add(new FrameInfo(filename, frameInfo.Delay, frameInfo.CursorX, frameInfo.CursorY, frameInfo.WasClicked, frameInfo.KeyList, frameInfo.Index));
+                    newList.Add(new FrameInfo(filename, frameInfo.Delay, frameInfo.CursorX, frameInfo.CursorY, frameInfo.ButtonClicked, frameInfo.KeyList, frameInfo.Index));
                 }
 
                 //Adds the current copied list to the clipboard.
@@ -78,7 +78,7 @@ namespace ScreenToGif.Util
                     File.Delete(frameInfo.Path);
 
                     //Create the new object and add to the list.
-                    newList.Add(new FrameInfo(filename, frameInfo.Delay, frameInfo.CursorX, frameInfo.CursorY, frameInfo.WasClicked, frameInfo.KeyList, frameInfo.Index));
+                    newList.Add(new FrameInfo(filename, frameInfo.Delay, frameInfo.CursorX, frameInfo.CursorY, frameInfo.ButtonClicked, frameInfo.KeyList, frameInfo.Index));
                 }
 
                 //Adds the current cut list to the clipboard.
@@ -112,7 +112,7 @@ namespace ScreenToGif.Util
                 File.Copy(frameInfo.Path, filename, true);
 
                 //Create the new object and add to the list.
-                newList.Add(new FrameInfo(filename, frameInfo.Delay, frameInfo.CursorX, frameInfo.CursorY, frameInfo.WasClicked, frameInfo.KeyList, frameInfo.Index));
+                newList.Add(new FrameInfo(filename, frameInfo.Delay, frameInfo.CursorX, frameInfo.CursorY, frameInfo.ButtonClicked, frameInfo.KeyList, frameInfo.Index));
             }
 
             return newList;

--- a/ScreenToGif/Util/MouseButtonType.cs
+++ b/ScreenToGif/Util/MouseButtonType.cs
@@ -1,0 +1,10 @@
+namespace ScreenToGif.Util
+{
+    public enum MouseButtonType
+    {
+        None,
+        Left,
+        Middle,
+        Right
+    }
+}

--- a/ScreenToGif/Util/Other.cs
+++ b/ScreenToGif/Util/Other.cs
@@ -364,7 +364,7 @@ namespace ScreenToGif.Util
 
         public static List<FrameInfo> CopyList(this List<FrameInfo> target)
         {
-            return new List<FrameInfo>(target.Select(s => new FrameInfo(s.Path, s.Delay, s.CursorX, s.CursorY, s.WasClicked, 
+            return new List<FrameInfo>(target.Select(s => new FrameInfo(s.Path, s.Delay, s.CursorX, s.CursorY, s.ButtonClicked,
                 s.KeyList != null ? new List<SimpleKeyGesture>(s.KeyList.Select(y => new SimpleKeyGesture(y.Key, y.Modifiers, y.IsUppercase, y.IsInjected))) : null, s.Index)));
         }
 
@@ -414,7 +414,7 @@ namespace ScreenToGif.Util
 
                 File.Copy(frame.Path, newPath);
 
-                list.Add(new FrameInfo(newPath, frame.Delay, frame.CursorX, frame.CursorY, frame.WasClicked, frame.KeyList, frame.Index));
+                list.Add(new FrameInfo(newPath, frame.Delay, frame.CursorX, frame.CursorY, frame.ButtonClicked, frame.KeyList, frame.Index));
             }
 
             return list;

--- a/ScreenToGif/Windows/Editor.xaml
+++ b/ScreenToGif/Windows/Editor.xaml
@@ -2970,6 +2970,8 @@
                                     <RowDefinition Height="Auto"/>
                                     <RowDefinition Height="Auto"/>
                                     <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
                                 </Grid.RowDefinitions>
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="Auto"/>
@@ -3004,19 +3006,26 @@
                                     <TextBlock Text="Rectangle" Tag="{StaticResource Vector.Rectangle}"/>
                                 </ComboBox>-->
 
-                                <TextBlock Grid.Row="1" Grid.Column="0" Text="{DynamicResource S.Caption.Color}" VerticalAlignment="Center" Foreground="{DynamicResource Element.Foreground.Medium}"/>
-                                <n:ColorBox Grid.Row="1" Grid.Column="1" x:Name="MouseBackgroundColor" Margin="10,5"
-                                            SelectedColor="{Binding Source={x:Static t:UserSettings.All}, Path=MouseClicksColor, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+                                <TextBlock Grid.Row="1" Grid.Column="0" Text="{DynamicResource S.Caption.LeftButton.Color}" VerticalAlignment="Center" Foreground="{DynamicResource Element.Foreground.Medium}"/>
+                                <n:ColorBox Grid.Row="1" Grid.Column="1" x:Name="LeftButtonClickColor" Margin="10,5"
+                                            SelectedColor="{Binding Source={x:Static t:UserSettings.All}, Path=LeftMouseButtonClicksColor, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
 
-                                <TextBlock Grid.Row="2" Grid.Column="0" Text="{DynamicResource S.FreeDrawing.Width}" VerticalAlignment="Center" Foreground="{DynamicResource Element.Foreground.Medium}"/>
-                                <n:DoubleUpDown Grid.Row="2" Grid.Column="1" x:Name="ClickWidthDoubleUpDown" Minimum="1" Maximum="1000" Margin="10,5" MinWidth="70" 
+                                <TextBlock Grid.Row="2" Grid.Column="0" Text="{DynamicResource S.Caption.MiddleButton.Color}" VerticalAlignment="Center" Foreground="{DynamicResource Element.Foreground.Medium}"/>
+                                <n:ColorBox Grid.Row="2" Grid.Column="1" x:Name="MiddleButtonClickColor" Margin="10,5"
+                                            SelectedColor="{Binding Source={x:Static t:UserSettings.All}, Path=MiddleMouseButtonClicksColor, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+
+                                <TextBlock Grid.Row="3" Grid.Column="0" Text="{DynamicResource S.Caption.RightButton.Color}" VerticalAlignment="Center" Foreground="{DynamicResource Element.Foreground.Medium}"/>
+                                <n:ColorBox Grid.Row="3" Grid.Column="1" x:Name="RightButtonClickColor" Margin="10,5"
+                                            SelectedColor="{Binding Source={x:Static t:UserSettings.All}, Path=RightMouseButtonClicksColor, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+
+                                <TextBlock Grid.Row="4" Grid.Column="0" Text="{DynamicResource S.FreeDrawing.Width}" VerticalAlignment="Center" Foreground="{DynamicResource Element.Foreground.Medium}"/>
+                                <n:DoubleUpDown Grid.Row="4" Grid.Column="1" x:Name="ClickWidthDoubleUpDown" Minimum="1" Maximum="1000" Margin="10,5" MinWidth="70"
                                                 Value="{Binding Source={x:Static t:UserSettings.All}, Path=MouseClicksWidth, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
 
-                                <TextBlock Grid.Row="3" Grid.Column="0" Text="{DynamicResource S.FreeDrawing.Height}" VerticalAlignment="Center" Foreground="{DynamicResource Element.Foreground.Medium}"/>
-                                <n:DoubleUpDown Grid.Row="3" Grid.Column="1" x:Name="ClickHeightDoubleUpDown" Minimum="1" Maximum="1000" Margin="10,5" MinWidth="70"
+                                <TextBlock Grid.Row="5" Grid.Column="0" Text="{DynamicResource S.FreeDrawing.Height}" VerticalAlignment="Center" Foreground="{DynamicResource Element.Foreground.Medium}"/>
+                                <n:DoubleUpDown Grid.Row="5" Grid.Column="1" x:Name="ClickHeightDoubleUpDown" Minimum="1" Maximum="1000" Margin="10,5" MinWidth="70"
                                                 Value="{Binding Source={x:Static t:UserSettings.All}, Path=MouseClicksHeight, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
                             </Grid>
-
                             <!--<n:LabelSeparator Grid.Row="2" Text="{DynamicResource S.Preview}"/>
                             <Grid Grid.Row="3" x:Name="PreviewGrid" Margin="10,5">
                                 <Viewbox x:Name="PreviewViewBox" Child="{StaticResource Vector.Cursor}" Height="20" Width="20" Stretch="Uniform">

--- a/ScreenToGif/Windows/Editor.xaml.cs
+++ b/ScreenToGif/Windows/Editor.xaml.cs
@@ -2511,7 +2511,7 @@ namespace ScreenToGif.Windows
 
         private void ApplyMouseClicksButton_Click(object sender, RoutedEventArgs e)
         {
-            if (!Project.Frames.Any(x => x.WasClicked))
+            if (Project.Frames.All(x => x.ButtonClicked == MouseButtonType.None))
             {
                 StatusList.Warning(LocalizationHelper.Get("S.MouseClicks.Warning.None"));
                 return;
@@ -6903,7 +6903,7 @@ namespace ScreenToGif.Windows
             var count = 0;
             foreach (var frame in auxList)
             {
-                if (!frame.WasClicked || frame.CursorX == int.MinValue)
+                if (frame.ButtonClicked == MouseButtonType.None || frame.CursorX == int.MinValue)
                 {
                     UpdateProgress(count++);
                     continue;
@@ -6913,10 +6913,31 @@ namespace ScreenToGif.Windows
                 var scale = Math.Round(image.DpiX / 96d, 2);
 
                 var drawingVisual = new DrawingVisual();
+                var leftClickSolidColorBrush = new SolidColorBrush(model.LeftButtonForegroundColor);
+                leftClickSolidColorBrush.Freeze();
+                var rightClickSolidColorBrush = new SolidColorBrush(model.RightButtonForegroundColor);
+                rightClickSolidColorBrush.Freeze();
+                var middleClickSolidColorBrush = new SolidColorBrush(model.MiddleButtonForegroundColor);
+                middleClickSolidColorBrush.Freeze();
                 using (var drawingContext = drawingVisual.RenderOpen())
                 {
                     drawingContext.DrawImage(image, new Rect(0, 0, image.Width, image.Height)); // - UserSettings.All.MouseClicksWidth/2d   // - UserSettings.All.MouseClicksHeight/2d
-                    drawingContext.DrawEllipse(new SolidColorBrush(model.ForegroundColor), null, new Point(frame.CursorX / scale, frame.CursorY / scale), model.Width, model.Height);
+
+                    SolidColorBrush brush = null;
+                    switch (frame.ButtonClicked)
+                    {
+                        case MouseButtonType.Left:
+                            brush = leftClickSolidColorBrush;
+                            break;
+                        case MouseButtonType.Right:
+                            brush = rightClickSolidColorBrush;
+                            break;
+                        case MouseButtonType.Middle:
+                            brush = middleClickSolidColorBrush;
+                            break;
+                    }
+                    drawingContext.DrawEllipse(brush, null,
+                            new Point(frame.CursorX / scale, frame.CursorY / scale), model.Width, model.Height);
                 }
 
                 //KeyStrokesOverlayGrid.GetScaledRender(ZoomBoxControl.ScaleDiff, ZoomBoxControl.ImageDpi, ZoomBoxControl.GetImageSize());

--- a/ScreenToGif/Windows/NewRecorder.xaml.cs
+++ b/ScreenToGif/Windows/NewRecorder.xaml.cs
@@ -559,8 +559,14 @@ namespace ScreenToGif.Windows
                 if (RegionSelectHelper.IsSelecting || Stage == Stage.Discarding)
                     return;
 
+                RecordClicked = MouseButtonType.None;
                 //In the future, store each mouse event, with a timestamp, independently of the capture.
-                RecordClicked = args.LeftButton == MouseButtonState.Pressed || args.RightButton == MouseButtonState.Pressed || args.MiddleButton == MouseButtonState.Pressed;
+                if (args.LeftButton == MouseButtonState.Pressed)
+                    RecordClicked = MouseButtonType.Left;
+                else if (args.RightButton == MouseButtonState.Pressed)
+                    RecordClicked = MouseButtonType.Right;
+                else if (args.MiddleButton == MouseButtonState.Pressed)
+                    RecordClicked = MouseButtonType.Middle;
 
                 _posX = (int)Math.Round(args.PosX / _regionSelection.Scale, MidpointRounding.AwayFromZero);
                 _posY = (int)Math.Round(args.PosY / _regionSelection.Scale, MidpointRounding.AwayFromZero);

--- a/ScreenToGif/Windows/Recorder.xaml.cs
+++ b/ScreenToGif/Windows/Recorder.xaml.cs
@@ -487,8 +487,14 @@ namespace ScreenToGif.Windows
                 if (RegionSelectHelper.IsSelecting || Stage == Stage.Discarding)
                     return;
 
+                RecordClicked = MouseButtonType.None;
                 //In the future, store each mouse event, with a timestamp, independently of the capture.
-                RecordClicked = args.LeftButton == MouseButtonState.Pressed || args.RightButton == MouseButtonState.Pressed || args.MiddleButton == MouseButtonState.Pressed;
+                if (args.LeftButton == MouseButtonState.Pressed)
+                    RecordClicked = MouseButtonType.Left;
+                else if (args.RightButton == MouseButtonState.Pressed)
+                    RecordClicked = MouseButtonType.Right;
+                else if (args.MiddleButton == MouseButtonState.Pressed)
+                    RecordClicked = MouseButtonType.Middle;
 
                 _posX = args.PosX;
                 _posY = args.PosY;


### PR DESCRIPTION
Loading old projects after this change will mark all the clicks as done by left mouse button, as previously no info was stored in the project file about mouse button type.
From this change the project will contain info about the button and different mouse clicks will be correctly represented.

There was some issue with migrating from old to new project format as there's not much control over the serialization/deserialization and in order not to lose clicks when importing from old format, some information had to be kept in the `FrameInfo` class. Saving in new format and loading in older version of application 9before this change) will result in Clicks being lost but the loading does not throw any exception..

Did testing of this new code and did not encountered any issues but please let me know if something if off.


Closes #900 