### PR TITLE
Follow system theme for editor's checkboard.

### DIFF
--- a/ScreenToGif/App.xaml.cs
+++ b/ScreenToGif/App.xaml.cs
@@ -334,7 +334,12 @@ namespace ScreenToGif
         private void SystemEvents_UserPreferenceChanged(object sender, UserPreferenceChangedEventArgs e)
         {
             if (e.Category == UserPreferenceCategory.General)
+            {
                 ThemeHelper.SelectTheme(UserSettings.All.MainTheme);
+                var isSystemUsingDark = ThemeHelper.IsSystemUsingDarkTheme();
+                UserSettings.All.GridColor1 = isSystemUsingDark ? Constants.DarkEven : Constants.VeryLightEven;
+                UserSettings.All.GridColor2 = isSystemUsingDark ? Constants.DarkOdd : Constants.VeryLightOdd;
+            }
         }
 
         private void App_Exit(object sender, ExitEventArgs e)

--- a/ScreenToGif/Settings/UserSettings.cs
+++ b/ScreenToGif/Settings/UserSettings.cs
@@ -1236,6 +1236,12 @@ namespace ScreenToGif.Settings
             set => SetValue(value);
         }
 
+        public bool GridColorsFollowSystem
+        {
+            get => (bool) GetValue(defaultValue: false);
+            set => SetValue(value);
+        }
+
         public Rect BoardGridSize
         {
             get => (Rect)GetValue();

--- a/ScreenToGif/Util/Constants.cs
+++ b/ScreenToGif/Util/Constants.cs
@@ -1,3 +1,4 @@
+using System.Windows.Media;
 using ScreenToGif.Settings;
 
 namespace ScreenToGif.Util
@@ -42,6 +43,22 @@ namespace ScreenToGif.Util
         public static int HorizontalBoardOffset => LeftBoardOffset + RightBoardOffset;
 
         public static int VerticalBoardOffset => TopBoardOffset + BottomBoardOffset;
+
+        #endregion
+
+        #region Colors
+
+        public static Color VeryLightEven = Color.FromArgb(255, 245, 245, 245);
+        public static Color VeryLightOdd = Color.FromArgb(255, 240, 240, 240);
+
+        public static Color LightEven = Color.FromArgb(255, 255, 255, 255);
+        public static Color LightOdd = Color.FromArgb(255, 211, 211, 211);
+
+        public static Color MediumEven = Color.FromArgb(255, 153, 153, 153);
+        public static Color MediumOdd = Color.FromArgb(255, 102, 102, 102);
+
+        public static Color DarkEven = Color.FromArgb(255, 45, 45, 45);
+        public static Color DarkOdd = Color.FromArgb(255, 50, 50, 50);
 
         #endregion
     }

--- a/ScreenToGif/Util/ThemeHelper.cs
+++ b/ScreenToGif/Util/ThemeHelper.cs
@@ -43,7 +43,7 @@ namespace ScreenToGif.Util
             RefreshNotificationIcon();
         }
 
-        private static bool IsSystemUsingDarkTheme()
+        internal static bool IsSystemUsingDarkTheme()
         {
             try
             {

--- a/ScreenToGif/Windows/Options.xaml
+++ b/ScreenToGif/Windows/Options.xaml
@@ -755,6 +755,11 @@
                                                 <Border BorderBrush="{DynamicResource Element.Border}" BorderThickness="0,1,1,1" Background="#FF2D2D2D" Width="20" Height="20"/>
                                                 <Label Content="{DynamicResource S.Options.App.Theme.Scheme.Dark}" Foreground="{DynamicResource Element.Foreground}" VerticalAlignment="Center" VerticalContentAlignment="Center" Padding="10,0,5,0"/>
                                             </StackPanel>
+                                            <StackPanel Orientation="Horizontal">
+                                                <Border BorderBrush="{DynamicResource Element.Border}" BorderThickness="1,1,0,1" Background="#FFF5F5F5" Width="20" Height="20"/>
+                                                <Border BorderBrush="{DynamicResource Element.Border}" BorderThickness="0,1,1,1" Background="#FF2D2D2D" Width="20" Height="20"/>
+                                                <Label Content="{DynamicResource S.Options.App.Theme.Scheme.FollowSystem}" Foreground="{DynamicResource Element.Foreground}" VerticalAlignment="Center" VerticalContentAlignment="Center" Padding="10,0,5,0"/>
+                                            </StackPanel>
                                             <Separator Height="1"/>
                                             <StackPanel Orientation="Horizontal">
                                                 <Border BorderBrush="{DynamicResource Element.Border}" BorderThickness="1,1,0,1" Width="20" Height="20">

--- a/ScreenToGif/Windows/Options.xaml.cs
+++ b/ScreenToGif/Windows/Options.xaml.cs
@@ -332,22 +332,6 @@ namespace ScreenToGif.Windows
 
         private void CheckScheme(bool schemePicked = true)
         {
-            #region Colors
-
-            var veryLightEven = Color.FromArgb(255, 245, 245, 245);
-            var veryLightOdd = Color.FromArgb(255, 240, 240, 240);
-
-            var lightEven = Color.FromArgb(255, 255, 255, 255);
-            var lightOdd = Color.FromArgb(255, 211, 211, 211);
-
-            var mediumEven = Color.FromArgb(255, 153, 153, 153);
-            var mediumOdd = Color.FromArgb(255, 102, 102, 102);
-
-            var darkEven = Color.FromArgb(255, 45, 45, 45);
-            var darkOdd = Color.FromArgb(255, 50, 50, 50);
-
-            #endregion
-
             try
             {
                 EvenColorBox.IgnoreEvent = true;
@@ -360,20 +344,30 @@ namespace ScreenToGif.Windows
                     switch (ColorSchemesComboBox.SelectedIndex)
                     {
                         case 0:
-                            UserSettings.All.GridColor1 = veryLightEven;
-                            UserSettings.All.GridColor2 = veryLightOdd;
+                            UserSettings.All.GridColorsFollowSystem = false;
+                            UserSettings.All.GridColor1 = Constants.VeryLightEven;
+                            UserSettings.All.GridColor2 = Constants.VeryLightOdd;
                             break;
                         case 1:
-                            UserSettings.All.GridColor1 = lightEven;
-                            UserSettings.All.GridColor2 = lightOdd;
+                            UserSettings.All.GridColorsFollowSystem = false;
+                            UserSettings.All.GridColor1 = Constants.LightEven;
+                            UserSettings.All.GridColor2 = Constants.LightOdd;
                             break;
                         case 2:
-                            UserSettings.All.GridColor1 = mediumEven;
-                            UserSettings.All.GridColor2 = mediumOdd;
+                            UserSettings.All.GridColorsFollowSystem = false;
+                            UserSettings.All.GridColor1 = Constants.MediumEven;
+                            UserSettings.All.GridColor2 = Constants.MediumOdd;
                             break;
                         case 3:
-                            UserSettings.All.GridColor1 = darkEven;
-                            UserSettings.All.GridColor2 = darkOdd;
+                            UserSettings.All.GridColorsFollowSystem = false;
+                            UserSettings.All.GridColor1 = Constants.DarkEven;
+                            UserSettings.All.GridColor2 = Constants.DarkOdd;
+                            break;
+                        case 4:
+                            UserSettings.All.GridColorsFollowSystem = true;
+                            var isSystemUsingDark = ThemeHelper.IsSystemUsingDarkTheme();
+                            UserSettings.All.GridColor1 = isSystemUsingDark ? Constants.DarkEven : Constants.VeryLightEven;
+                            UserSettings.All.GridColor2 = isSystemUsingDark ? Constants.DarkOdd : Constants.VeryLightOdd;
                             break;
                     }
 
@@ -383,17 +377,26 @@ namespace ScreenToGif.Windows
                 }
 
                 #region If Color Picked
-
-                if (UserSettings.All.GridColor1.Equals(veryLightEven) && UserSettings.All.GridColor2.Equals(veryLightOdd))
+                if (UserSettings.All.GridColor1.Equals(Constants.VeryLightEven) && UserSettings.All.GridColor2.Equals(Constants.VeryLightOdd) &&
+                    !UserSettings.All.GridColorsFollowSystem)
                     ColorSchemesComboBox.SelectedIndex = 0;
-                else if (UserSettings.All.GridColor1.Equals(lightEven) && UserSettings.All.GridColor2.Equals(lightOdd))
+                else if (UserSettings.All.GridColor1.Equals(Constants.LightEven) && UserSettings.All.GridColor2.Equals(Constants.LightOdd))
                     ColorSchemesComboBox.SelectedIndex = 1;
-                else if (UserSettings.All.GridColor1.Equals(mediumEven) && UserSettings.All.GridColor2.Equals(mediumOdd))
+                else if (UserSettings.All.GridColor1.Equals(Constants.MediumEven) &&
+                         UserSettings.All.GridColor2.Equals(Constants.MediumOdd))
                     ColorSchemesComboBox.SelectedIndex = 2;
-                else if (UserSettings.All.GridColor1.Equals(darkEven) && UserSettings.All.GridColor2.Equals(darkOdd))
+                else if (UserSettings.All.GridColor1.Equals(Constants.DarkEven) && UserSettings.All.GridColor2.Equals(Constants.DarkOdd) &&
+                         !UserSettings.All.GridColorsFollowSystem)
                     ColorSchemesComboBox.SelectedIndex = 3;
+                else if (UserSettings.All.GridColorsFollowSystem &&
+                         (UserSettings.All.GridColor1.Equals(Constants.VeryLightEven) || UserSettings.All.GridColor1.Equals(Constants.DarkEven))
+                         && (UserSettings.All.GridColor2.Equals(Constants.VeryLightOdd) || UserSettings.All.GridColor2.Equals(Constants.DarkOdd)))
+                    ColorSchemesComboBox.SelectedIndex = 4;
                 else
-                    ColorSchemesComboBox.SelectedIndex = 5;
+                {
+                    UserSettings.All.GridColorsFollowSystem = false;
+                    ColorSchemesComboBox.SelectedIndex = 6;
+                }
 
                 #endregion
             }


### PR DESCRIPTION
Added an option to set Editor's checkboard to follow system theme settings.

As the grid colors are set on specific colors in order to correctly keep the info about 'FollowSystem' option, and additional settings property was created to hold the value ('GridColorsFollowSystem`).

Additionally checkboard colors were extracted to existing Constants class in order to reuse them from certain parts of the code.

As a note, `Options.xaml.cs` class could be cleaned up a little bit in regards to those colors i.e. dead code in `CheckBoardScheme` but don't know whether I should do such changes in the same PR.

Closes #910 (though I didn't change the behavior about the title bar)