### PR TITLE
Fix missing extension in case location is not specified by the user.

### DIFF
--- a/ScreenToGif/Util/EncodingManager.cs
+++ b/ScreenToGif/Util/EncodingManager.cs
@@ -480,14 +480,14 @@ namespace ScreenToGif.Util
                 else
                 {
                     preset.OutputFolder = Path.GetTempPath(); //Get path where the cache is stored instead.
-                    preset.OutputFilename = Guid.NewGuid() + "";
-                    preset.FullPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+                    preset.OutputFilename = Guid.NewGuid() + preset.Extension;
+                    preset.FullPath = Path.Combine(preset.OutputFolder, preset.OutputFilename);
 
                     //If somehow this happens, try again. TODO: File should be created on the spot, to properly prevent this issue.
                     if (File.Exists(Path.Combine(preset.OutputFilename, preset.OutputFilename)))
                     {
-                        preset.OutputFilename = Guid.NewGuid() + "";
-                        preset.FullPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+                        preset.OutputFilename = Guid.NewGuid() + preset.Extension;
+                        preset.FullPath = Path.Combine(preset.OutputFolder, preset.OutputFilename);
                     }
                 }
 


### PR DESCRIPTION
preset.Extension was not used when generating the file name when location was not picked by the user.

Also did some cleaning up as it looked like `OutputFileName` was set to a different guid than the guid used in file name in the `FullPath`.

Closes #913 