### PR TITLE
NewRecorder: Fix for splash not being hidden

### DIFF
--- a/ScreenToGif/Windows/NewRecorder.xaml.cs
+++ b/ScreenToGif/Windows/NewRecorder.xaml.cs
@@ -602,10 +602,9 @@ namespace ScreenToGif.Windows
             }
 
             _preStartTimer.Stop();
-            
+            Splash.Dismiss();
             if (IsRegionIntersected())
             {
-                Splash.Dismiss();
                 WindowState = WindowState.Minimized;
             }
 


### PR DESCRIPTION
A small usability fix.

When the recording controls overlap recording area a splash window is displayed with the countdown. If user would move the control outside the recording area before the countdown reaches zero the splash would stay forever. This commit fixes that.