### PR TITLE
Call Activate on Editor when showing the recorder popup

### DIFF
--- a/ScreenToGif/Windows/Editor.xaml.cs
+++ b/ScreenToGif/Windows/Editor.xaml.cs
@@ -685,6 +685,7 @@ namespace ScreenToGif.Windows
 
         public void RecorderCallback(ProjectInfo project)
         {
+            Activate();
             if (project?.Any == true)
             {
                 LoadProject(project);


### PR DESCRIPTION
Activate is needed to make sure the popup has the focus so that it can be controlled via keyboard.

Fixes #930 