### PR TITLE
Allow more keys to be part of a shortcut in conj. with modifier keys.

### DIFF
--- a/ScreenToGif/Controls/KeyBox.cs
+++ b/ScreenToGif/Controls/KeyBox.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
@@ -286,9 +286,9 @@ namespace ScreenToGif.Controls
                 //If any modifier.
                 if (IsControlDown || IsAltDown || IsShiftDown || IsWindowsDown)
                 {
-                    if ((int)key > 33 && (int)key < 114)
+                    if (((int)key > 33 && (int)key < 114) || ((int)key >139 && (int)key < 155))
                     {
-                        //D0 to F24. Valid combinations.
+                        //D0 to F24 and Oem1 to OemBackslash. Valid combinations.
                         ModifierKeys = Keyboard.Modifiers;
                         MainKey = key;
                         _finished = true;


### PR DESCRIPTION
With this change it is possible to use more characters with controling characters (CTRL, ALT, SHIFT) so some previously impossible keyboard shortcuts are not possible to be set.

Closes #937.