### PR TITLE
feat: add manual update button

### DIFF
--- a/ScreenToGif/App.xaml.cs
+++ b/ScreenToGif/App.xaml.cs
@@ -233,7 +233,7 @@ namespace ScreenToGif
             #region Tasks
 
             Task.Factory.StartNew(MainViewModel.ClearTemporaryFiles, TaskCreationOptions.LongRunning);
-            Task.Factory.StartNew(MainViewModel.CheckForUpdates, TaskCreationOptions.LongRunning);
+            Task.Factory.StartNew(MainViewModel.CheckForUpdates,true,TaskCreationOptions.LongRunning);
             Task.Factory.StartNew(MainViewModel.SendFeedback, TaskCreationOptions.LongRunning);
 
             #endregion

--- a/ScreenToGif/Model/ApplicationViewModel.cs
+++ b/ScreenToGif/Model/ApplicationViewModel.cs
@@ -878,16 +878,18 @@ namespace ScreenToGif.Model
             }
         }
 
-        internal async void CheckForUpdates()
+        internal async Task CheckForUpdates(object obj)
         {
             Global.UpdateAvailable = null;
 
 #if UWP
             return;
 #endif
-
-            if (!UserSettings.All.CheckForUpdates)
-                return;
+            if (obj is bool flag && flag)
+            {
+                if (!UserSettings.All.CheckForUpdates)
+                    return;
+            }
 
             //Try checking for the update on Github first then fallbacks to Fosshub.
             if (!await CheckOnGithub())

--- a/ScreenToGif/Resources/Localization/StringResources.en.xaml
+++ b/ScreenToGif/Resources/Localization/StringResources.en.xaml
@@ -613,6 +613,8 @@
     
     <!--Options • About-->
     <s:String x:Key="S.Options.About.Version">Version:</s:String>
+    <s:String x:Key="S.Options.About.UpdateCheck">Check for Update</s:String>
+    <s:String x:Key="S.Options.About.UpdateCheckForNothing">Your version is the latest, there's nothing to update.</s:String>
     <s:String x:Key="S.Options.About.Author">Author: Nicke Manarin</s:String>
     <s:String x:Key="S.Options.About.StoreVersion">Microsoft Store version. Some features are disabled due to enforced policies.</s:String>
     <s:String x:Key="S.Options.About.Contact">Contact</s:String>

--- a/ScreenToGif/Resources/Localization/StringResources.zh.xaml
+++ b/ScreenToGif/Resources/Localization/StringResources.zh.xaml
@@ -613,6 +613,8 @@
     
     <!--Options • About-->
     <s:String x:Key="S.Options.About.Version">版本：</s:String>
+    <s:String x:Key="S.Options.About.UpdateCheck">检查更新</s:String>
+    <s:String x:Key="S.Options.About.UpdateCheckForNothing">你已经更新到最新版本，无需更新。</s:String>
     <s:String x:Key="S.Options.About.Author">作者：Nicke Manarin</s:String>
     <s:String x:Key="S.Options.About.StoreVersion">Microsoft Store 版本。 某些功能由于强制策略而被禁用。</s:String>
     <s:String x:Key="S.Options.About.Contact">联系</s:String>

--- a/ScreenToGif/Windows/Options.xaml
+++ b/ScreenToGif/Windows/Options.xaml
@@ -1838,6 +1838,11 @@
                             <StackPanel Grid.Row="0" Grid.Column="2" Orientation="Horizontal">
                                 <Label Content="{DynamicResource S.Options.About.Version}" FontSize="18" VerticalContentAlignment="Center" Foreground="{DynamicResource Element.Foreground}"/>
                                 <Label Content="{Binding Source={x:Static t:UserSettings.All}, Path=VersionText}" FontSize="18" VerticalContentAlignment="Center" Foreground="{DynamicResource Element.Foreground}"/>
+                                 <Label VerticalContentAlignment ="Center">
+                                    <Hyperlink Click="Hyperlink_OnCheckUpdate" Cursor="Hand">
+                                        <Run Text="{DynamicResource S.Options.About.UpdateCheck}"/>
+                                    </Hyperlink>
+                                </Label>
                             </StackPanel>
 
                             <Label Grid.Row="1" Grid.Column="1" FontSize="16" HorizontalAlignment="Right" Cursor="Hand" Padding="3,5" VerticalContentAlignment="Center">

--- a/ScreenToGif/Windows/Options.xaml.cs
+++ b/ScreenToGif/Windows/Options.xaml.cs
@@ -18,6 +18,7 @@ using System.Windows.Navigation;
 using System.Windows.Threading;
 using Microsoft.Win32;
 using ScreenToGif.Controls;
+using ScreenToGif.Model;
 using ScreenToGif.Model.ExportPresets;
 using ScreenToGif.Model.UploadPresets;
 using ScreenToGif.Settings;
@@ -741,7 +742,6 @@ namespace ScreenToGif.Windows
                 LogWriter.Log(ex, "Open MailTo");
             }
         }
-
         #endregion
 
         #region Storage
@@ -2071,6 +2071,22 @@ namespace ScreenToGif.Windows
             }
         }
 
+        private async void Hyperlink_OnCheckUpdate(object sender, RoutedEventArgs e)
+        {
+            await App.MainViewModel.CheckForUpdates(false);
+
+            if (Global.UpdateAvailable == null)
+            {
+                Dialog.Ok(LocalizationHelper.Get("S.Options.About.UpdateCheck"),
+                        LocalizationHelper.Get("S.Options.About.UpdateCheck"),
+                        LocalizationHelper.Get("S.Options.About.UpdateCheckForNothing"),
+                        Icons.Info);
+            }
+            else
+            {
+                App.MainViewModel.PromptUpdate.Execute(null);
+            }
+        }
         #endregion
 
         #region Other

--- a/ScreenToGif/Windows/Other/DownloadDialog.xaml.cs
+++ b/ScreenToGif/Windows/Other/DownloadDialog.xaml.cs
@@ -206,7 +206,7 @@ namespace ScreenToGif.Windows.Other
             DownloadProgressBar.Visibility = Visibility.Visible;
             RunAfterwardsCheckBox.Visibility = Visibility.Collapsed;
 
-            var result = await Task.Run(async () => await App.MainViewModel.DownloadUpdate());
+            var result = await App.MainViewModel.DownloadUpdate();
 
             //If cancelled.
             if (!IsLoaded)


### PR DESCRIPTION
Ref: https://github.com/NickeManarin/ScreenToGif/issues/954.

Actual Demo:

1. There's a "Check For Update" button on the "About" UI:
2. 
![Main](https://user-images.githubusercontent.com/52018749/127470023-5a8172dd-0549-4175-8355-4129365cd353.JPG)

2. When your current version is lower than the latest, and when you click the "Check For Update", a download dialog will show to you:

![Downloading](https://user-images.githubusercontent.com/52018749/127469948-c9931ffd-6aa3-4254-aa6d-13ea5bd57abb.JPG)

3. After installing successfully, there'a tip for you saying "there's nothing to update":
![Updated](https://user-images.githubusercontent.com/52018749/127470475-e07ffa87-a726-4ee0-aedd-3f741d9bdb6a.JPG)
