### PR TITLE
fix: Exception for x86 on Gifski

### DIFF
--- a/ScreenToGif/Util/FunctionLoader.cs
+++ b/ScreenToGif/Util/FunctionLoader.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Runtime.InteropServices;
 
 namespace ScreenToGif.Util
@@ -14,12 +14,14 @@ namespace ScreenToGif.Util
         [DllImport("Kernel32.dll")]
         private static extern IntPtr GetProcAddress(IntPtr hModule, string procName);
 
-        internal static Delegate LoadFunction<T>(string dllPath, string functionName)
+        internal static T LoadFunction<T>(string dllPath, string functionName) where T : Delegate
         {
-            var hModule = LoadLibrary(dllPath);
-            var functionAddress = GetProcAddress(hModule, functionName);
+            {
+                var hModule = LoadLibrary(dllPath);
+                var functionAddress = GetProcAddress(hModule, functionName);
 
-            return Marshal.GetDelegateForFunctionPointer(functionAddress, typeof(T));
+                return (T)Marshal.GetDelegateForFunctionPointer(functionAddress, typeof(T));
+            }
         }
     }
 }

--- a/ScreenToGif/Util/GifskiInterop.cs
+++ b/ScreenToGif/Util/GifskiInterop.cs
@@ -188,27 +188,27 @@ namespace ScreenToGif.Util
 
             #region Load functions
 
-            _new = (NewDelegate)FunctionLoader.LoadFunction<NewDelegate>(UserSettings.All.GifskiLocation, "gifski_new");
-            _addPngFrame = (AddPngFrameDelegate)FunctionLoader.LoadFunction<AddPngFrameDelegate>(UserSettings.All.GifskiLocation, "gifski_add_frame_png_file");
+            _new = FunctionLoader.LoadFunction<NewDelegate>(UserSettings.All.GifskiLocation, "gifski_new");
+            _addPngFrame = FunctionLoader.LoadFunction<AddPngFrameDelegate>(UserSettings.All.GifskiLocation, "gifski_add_frame_png_file");
             //_addRgbaFrame = (AddRgbaFrameDelegate)FunctionLoader.LoadFunction<AddRgbaFrameDelegate>(UserSettings.All.GifskiLocation, "gifski_add_frame_rgba");
 
             if (Version.Major == 0 && Version.Minor < 10)
-                _addRgbFrame = (AddRgbFrameDelegate)FunctionLoader.LoadFunction<AddRgbFrameDelegate>(UserSettings.All.GifskiLocation, "gifski_add_frame_rgb");
+                _addRgbFrame = FunctionLoader.LoadFunction<AddRgbFrameDelegate>(UserSettings.All.GifskiLocation, "gifski_add_frame_rgb");
             else
-                _addRgb2Frame = (AddRgb2FrameDelegate)FunctionLoader.LoadFunction<AddRgb2FrameDelegate>(UserSettings.All.GifskiLocation, "gifski_add_frame_rgb");
+                _addRgb2Frame = FunctionLoader.LoadFunction<AddRgb2FrameDelegate>(UserSettings.All.GifskiLocation, "gifski_add_frame_rgb");
 
             if (Version.Major == 0 && Version.Minor < 9)
             {
                 //Older versions of the library.
-                _endAddingFrames = (EndAddingFramesDelegate)FunctionLoader.LoadFunction<EndAddingFramesDelegate>(UserSettings.All.GifskiLocation, "gifski_end_adding_frames");
-                _write = (WriteDelegate)FunctionLoader.LoadFunction<WriteDelegate>(UserSettings.All.GifskiLocation, "gifski_write");
-                _drop = (DropDelegate)FunctionLoader.LoadFunction<DropDelegate>(UserSettings.All.GifskiLocation, "gifski_drop");
+                _endAddingFrames = FunctionLoader.LoadFunction<EndAddingFramesDelegate>(UserSettings.All.GifskiLocation, "gifski_end_adding_frames");
+                _write = FunctionLoader.LoadFunction<WriteDelegate>(UserSettings.All.GifskiLocation, "gifski_write");
+                _drop = FunctionLoader.LoadFunction<DropDelegate>(UserSettings.All.GifskiLocation, "gifski_drop");
             }
             else
             {
                 //Newer versions.
-                _setFileOutput = (SetFileOutputDelegate)FunctionLoader.LoadFunction<SetFileOutputDelegate>(UserSettings.All.GifskiLocation, "gifski_set_file_output");
-                _finish = (FinishDelegate)FunctionLoader.LoadFunction<FinishDelegate>(UserSettings.All.GifskiLocation, "gifski_finish");
+                _setFileOutput = FunctionLoader.LoadFunction<SetFileOutputDelegate>(UserSettings.All.GifskiLocation, "gifski_set_file_output");
+                _finish = FunctionLoader.LoadFunction<FinishDelegate>(UserSettings.All.GifskiLocation, "gifski_finish");
             }
 
             #endregion

--- a/ScreenToGif/Windows/Options.xaml.cs
+++ b/ScreenToGif/Windows/Options.xaml.cs
@@ -1278,6 +1278,10 @@ namespace ScreenToGif.Windows
         private void ExtrasGrid_Loaded(object sender, RoutedEventArgs e)
         {
             CheckTools();
+
+            // Don't load it unless it's x64, because gifski
+            // doesn't support x86
+            GifskiImageCard.IsEnabled = Environment.Is64BitProcess;
         }
 
         private async void FfmpegImageCard_Click(object sender, RoutedEventArgs e)

--- a/ScreenToGif/Windows/Other/Preset.xaml.cs
+++ b/ScreenToGif/Windows/Other/Preset.xaml.cs
@@ -42,7 +42,7 @@ namespace ScreenToGif.Windows.Other
                 case Export.Gif:
                     EncoderScreenToGifItem.IsEnabled = true;
                     EncoderFfmpegItem.IsEnabled = true;
-                    EncoderGifskiItem.IsEnabled = true;
+                    EncoderGifskiItem.IsEnabled = Environment.Is64BitProcess;
                     EncoderSystemItem.IsEnabled = true;
                     break;
                 case Export.Apng:


### PR DESCRIPTION
1. Ref: https://github.com/NickeManarin/ScreenToGif/issues/962, with some codes formation.

After fix, disable download gifski and disable choices of gifski for x86:
![choose](https://user-images.githubusercontent.com/52018749/128440850-07b5798a-9f8a-4b45-833c-043d995a67c7.png)
![download](https://user-images.githubusercontent.com/52018749/128440857-743fa629-f3a9-4a67-8498-fb9dd9e135c7.JPG)
![preset1](https://user-images.githubusercontent.com/52018749/128440859-9c9532fc-4390-4845-9868-96b37bc49c6d.png)
![preset2](https://user-images.githubusercontent.com/52018749/128440865-be16233a-c6bd-44bf-9035-6f61176be82d.png)

For more: https://github.com/ImageOptim/gifski/issues/189

2. Remove exclipit conversion from Delegate to a generic type by using "where".