### PR TITLE
Modified to avoid binding-related warning messages when running the editor

### DIFF
--- a/ScreenToGif/ScreenToGif.csproj
+++ b/ScreenToGif/ScreenToGif.csproj
@@ -385,6 +385,7 @@
     <Compile Include="Model\ExportPresets\Video\Webm\FfmpegWebmPreset.cs" />
     <Compile Include="Model\ExportPresets\Video\Webm\WebmPreset.cs" />
     <Compile Include="Settings\Migrations\Migration2_31_0To2_32_0.cs" />
+    <Compile Include="Util\Converters\DoubleToNotNanDouble.cs" />
     <Compile Include="ViewModel\FrameViewModel.cs" />
     <Compile Include="ViewModel\Tasks\ResizeViewModel.cs" />
     <Compile Include="ViewModel\Tasks\ShadowViewModel.cs" />

--- a/ScreenToGif/Util/Converters/DoubleToNotNanDouble.cs
+++ b/ScreenToGif/Util/Converters/DoubleToNotNanDouble.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+
+namespace ScreenToGif.Util.Converters
+{
+    /// <summary>
+    /// Double to NotNanDouble converter.
+    /// </summary>
+    public class DoubleToNotNanDouble : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            var number = value as double?;
+
+            if (!number.HasValue || Double.IsNaN(number.Value))
+                return DependencyProperty.UnsetValue;
+
+            return number;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            var number = value as double?;
+
+            if (!number.HasValue || Double.IsNaN(number.Value))
+                return DependencyProperty.UnsetValue;
+
+            return number;
+        }
+    }
+}

--- a/ScreenToGif/Windows/Editor.xaml
+++ b/ScreenToGif/Windows/Editor.xaml
@@ -34,6 +34,7 @@
         <c:BoolAndToVisibility x:Key="BoolAndToVisibility"/>
         <c:IntToBool x:Key="IntToBool"/>
         <c:BoolAndOrOrToVisibility x:Key="BoolAndOrOrToVisibility"/>
+        <c:DoubleToNotNanDouble x:Key="DoubleToNotNanDouble"/>
 
         <Storyboard x:Key="ShowPanelStoryboard">
             <BooleanAnimationUsingKeyFrames Storyboard.TargetName="ActionGrid" Storyboard.TargetProperty="IsHitTestVisible" Duration="0:0:0" >
@@ -1335,8 +1336,8 @@
                     <Grid x:Name="BorderPreviewGrid" VerticalAlignment="Center" HorizontalAlignment="Center"
                           Visibility="{Binding ElementName=BorderGrid, Path=Visibility}" Background="White">
                         <Border x:Name="BorderBehindOverlayBorder" VerticalAlignment="Center" HorizontalAlignment="Center"
-                                MinWidth="{Binding ElementName=CaptionOverlayGrid, Path=Width, FallbackValue=0}" 
-                                MinHeight="{Binding ElementName=CaptionOverlayGrid, Path=Height, FallbackValue=0}"
+                                MinWidth="{Binding ElementName=CaptionOverlayGrid, Path=Width, FallbackValue=0, Converter={StaticResource DoubleToNotNanDouble}}" 
+                                MinHeight="{Binding ElementName=CaptionOverlayGrid, Path=Height, FallbackValue=0, Converter={StaticResource DoubleToNotNanDouble}}"
                                 BorderBrush="{Binding ElementName=BorderColorBox, Path=SelectedBrush}">
                             <Border.BorderThickness>
                                 <MultiBinding Converter="{StaticResource DoubleToThicknessConverter}" ConverterParameter="-">


### PR DESCRIPTION
Add converter not to return NaN, as a warning occurs when the Width and Height values of CaptionOverlayGrid are Double.NaN.