### PR TITLE
Update StringResources.pl.xaml

### DIFF
--- a/ScreenToGif/Resources/Localization/StringResources.pl.xaml
+++ b/ScreenToGif/Resources/Localization/StringResources.pl.xaml
@@ -721,9 +721,9 @@
     <s:String x:Key="S.Editor.Image">Obraz</s:String>
     <s:String x:Key="S.Editor.Transitions">Przejścia</s:String>
     <s:String x:Key="S.Editor.Statistics">Statystyki</s:String>
-    <s:String x:Key="S.Editor.Options">Opcje</s:String>
+    <s:String x:Key="S.Editor.Options">Ustawienia</s:String>
     <s:String x:Key="S.Editor.Help">Pomoc</s:String>
-    <s:String x:Key="S.Editor.Extras">Dodatki</s:String>
+    <s:String x:Key="S.Editor.Extras">Opcje</s:String>
     <!--<s:String x:Key="S.Editor.UpdateAvailable">A new update is available!</s:String>-->
     <!--<s:String x:Key="S.Editor.UpdateAvailable.Info">Click here to read more about it.</s:String>-->
     <s:String x:Key="S.Editor.FrameNumbersInfo">Całkowita liczba klatek, liczba wybranych klatek, indeks wybranych klatek</s:String>


### PR DESCRIPTION
line 726 "Dodatki" is more realated to "addons", while "opcje" (traslate to: options) indicates more clearly what the button purpose is.
line 724 "Opcje" means options but to avoid repeating text after translation above I propose a change to "ustawienia" which means literally "settings"

I propose these changes because I coulnd't find the "settings" button because it was hidden under menu that was named like "addons"
These are the words I wanted to change: https://imgur.com/a/z5B9IEE