### PR TITLE
Highlight mouse cursor even when no buttons are pressed

### DIFF
--- a/ScreenToGif.Model/Enums/PanelType.cs
+++ b/ScreenToGif.Model/Enums/PanelType.cs
@@ -69,9 +69,9 @@ public enum PanelTypes
     RemoveDuplicates = 13,
 
     /// <summary>
-    /// Mouse Clicks Panel.
+    /// Mouse Events Panel.
     /// </summary>
-    MouseClicks = 14,
+    MouseEvents = 14,
 
     /// <summary>
     /// Smooth Loop Panel.

--- a/ScreenToGif.Model/Enums/TaskTypes.cs
+++ b/ScreenToGif.Model/Enums/TaskTypes.cs
@@ -3,7 +3,7 @@ namespace ScreenToGif.Domain.Enums;
 public enum TaskTypes
 {
     NotDeclared = 0,
-    MouseClicks = 1,
+    MouseEvents = 1,
     KeyStrokes = 2,
     Delay = 3,
     Progress = 4,

--- a/ScreenToGif.Util/Settings/Migrations.cs
+++ b/ScreenToGif.Util/Settings/Migrations.cs
@@ -48,6 +48,10 @@ public static class Migration
                 Migration2_35_0To2_36_0.Up(properties);
                 goto default;
 
+            case "2.36": //To 2.37
+                Migration2_36_0To2_37_0.Up(properties);
+                goto default;
+
             default:
             {
                 properties.RemoveAll(p => p.Key == "Version");

--- a/ScreenToGif.Util/Settings/Migrations/Migration2_36_0To2_37_0.cs
+++ b/ScreenToGif.Util/Settings/Migrations/Migration2_36_0To2_37_0.cs
@@ -1,0 +1,68 @@
+using ScreenToGif.Domain.Models;
+
+namespace ScreenToGif.Settings.Migrations;
+
+internal class Migration2_36_0To2_37_0
+{
+    internal static bool Up(List<Property> properties)
+    {
+        // Rename properties
+        var mouseClicksWidth = properties.FirstOrDefault(a => a.Key == "MouseClicksWidth");
+        if (mouseClicksWidth != null)
+        {
+            mouseClicksWidth.Key = "MouseEventsWidth";
+        }
+
+        var mouseClicksHeight = properties.FirstOrDefault(a => a.Key == "MouseClicksHeight");
+        if (mouseClicksHeight != null)
+        {
+            mouseClicksHeight.Key = "MouseEventsHeight";
+        }
+
+        // Add new property
+        if (!properties.Any(a => a.Key == "MouseHighlightColor"))
+        {
+            properties.Add(new Property()
+            {
+                Key = "MouseHighlightColor",
+                Type = "Color",
+                Value = "#000000FF",
+            });
+        }
+
+        UpdateTasks(properties);
+
+        return true;
+    }
+
+    private static void UpdateTasks(List<Property> properties)
+    {
+        // Update tasks
+        var tasks = properties.FirstOrDefault(f => f.Key == "AutomatedTasksList");
+
+        if (tasks != null)
+        {
+            foreach (var task in tasks.Children)
+            {
+                if (task.Type == "MouseClicksViewModel")
+                {
+                    task.Type = "MouseEventsViewModel";
+                    var taskTypeAttribute = task.Attributes.FirstOrDefault(a => a.Key == "TaskType");
+                    if (taskTypeAttribute != null)
+                    {
+                        taskTypeAttribute.Value = "MouseEvents";
+                    }
+
+                    if (!task.Attributes.Any(a => a.Key == "HighlightForegroundColor"))
+                    {
+                        task.Attributes.Add(new Property()
+                        {
+                            Key = "HighlightForegroundColor",
+                            Value = "#000000FF",
+                        });
+                    }
+                }
+            }
+        }
+    }
+}

--- a/ScreenToGif.Util/Settings/UserSettings.cs
+++ b/ScreenToGif.Util/Settings/UserSettings.cs
@@ -2538,7 +2538,13 @@ public class UserSettings : INotifyPropertyChanged
 
     #endregion
 
-    #region Editor • Mouse Clicks
+    #region Editor • Mouse Events
+
+    public Color MouseHighlightColor
+    {
+        get => (Color)GetValue();
+        set => SetValue(value);
+    }
 
     public Color LeftMouseButtonClicksColor
     {
@@ -2558,13 +2564,13 @@ public class UserSettings : INotifyPropertyChanged
         set => SetValue(value);
     }
 
-    public double MouseClicksWidth
+    public double MouseEventsWidth
     {
         get => (double)GetValue();
         set => SetValue(value);
     }
 
-    public double MouseClicksHeight
+    public double MouseEventsHeight
     {
         get => (double)GetValue();
         set => SetValue(value);

--- a/ScreenToGif.ViewModel/Tasks/BaseTaskViewModel.cs
+++ b/ScreenToGif.ViewModel/Tasks/BaseTaskViewModel.cs
@@ -30,8 +30,8 @@ public class BaseTaskViewModel : BindableBase, IPersistent
         {
             switch (TaskType)
             {
-                case TaskTypes.MouseClicks:
-                    return LocalizationHelper.Get("S.Editor.Image.Clicks", true);
+                case TaskTypes.MouseEvents:
+                    return LocalizationHelper.Get("S.Editor.Image.MouseEvents", true);
                 case TaskTypes.KeyStrokes:
                     return LocalizationHelper.Get("S.Editor.Image.KeyStrokes", true);
                 case TaskTypes.Delay:

--- a/ScreenToGif.ViewModel/Tasks/MouseEventsViewModel.cs
+++ b/ScreenToGif.ViewModel/Tasks/MouseEventsViewModel.cs
@@ -5,17 +5,24 @@ using ScreenToGif.Util.Settings;
 
 namespace ScreenToGif.ViewModel.Tasks;
 
-public class MouseClicksViewModel : BaseTaskViewModel
+public class MouseEventsViewModel : BaseTaskViewModel
 {
     private Color _leftButtonForegroundColor;
     private Color _rightButtonForegroundColor;
     private Color _middleButtonForegroundColor;
+    private Color _highlightForegroundColor;
     private double _width;
     private double _height;
 
-    public MouseClicksViewModel()
+    public MouseEventsViewModel()
     {
-        TaskType = TaskTypes.MouseClicks;
+        TaskType = TaskTypes.MouseEvents;
+    }
+
+    public Color HighlightForegroundColor
+    {
+        get => _highlightForegroundColor;
+        set => SetProperty(ref _highlightForegroundColor, value);
     }
 
     public Color LeftButtonForegroundColor
@@ -50,33 +57,36 @@ public class MouseClicksViewModel : BaseTaskViewModel
 
     public override string ToString()
     {
-        return $"{LocalizationHelper.Get("S.MouseClicks.Color.Left")} #{LeftButtonForegroundColor.A:X2}{LeftButtonForegroundColor.R:X2}{LeftButtonForegroundColor.G:X2}{LeftButtonForegroundColor.B:X2}, "+
-               $"{LocalizationHelper.Get("S.MouseClicks.Color.Middle")} #{MiddleButtonForegroundColor.A:X2}{MiddleButtonForegroundColor.R:X2}{MiddleButtonForegroundColor.G:X2}{MiddleButtonForegroundColor.B:X2}, "+
-               $"{LocalizationHelper.Get("S.MouseClicks.Color.Right")} #{RightButtonForegroundColor.A:X2}{RightButtonForegroundColor.R:X2}{RightButtonForegroundColor.G:X2}{RightButtonForegroundColor.B:X2}, "+
+        return $"{LocalizationHelper.Get("S.MouseHighlight.Color")} #{HighlightForegroundColor.A:X2}{HighlightForegroundColor.R:X2}{HighlightForegroundColor.G:X2}{HighlightForegroundColor.B:X2}, " +
+            $"{LocalizationHelper.Get("S.MouseClicks.Color.Left")} #{LeftButtonForegroundColor.A:X2}{LeftButtonForegroundColor.R:X2}{LeftButtonForegroundColor.G:X2}{LeftButtonForegroundColor.B:X2}, " +
+               $"{LocalizationHelper.Get("S.MouseClicks.Color.Middle")} #{MiddleButtonForegroundColor.A:X2}{MiddleButtonForegroundColor.R:X2}{MiddleButtonForegroundColor.G:X2}{MiddleButtonForegroundColor.B:X2}, " +
+               $"{LocalizationHelper.Get("S.MouseClicks.Color.Right")} #{RightButtonForegroundColor.A:X2}{RightButtonForegroundColor.R:X2}{RightButtonForegroundColor.G:X2}{RightButtonForegroundColor.B:X2}, " +
                $"{LocalizationHelper.Get("S.FreeDrawing.Width")} {Width}, {LocalizationHelper.Get("S.FreeDrawing.Height")} {Height}";
     }
 
-    public static MouseClicksViewModel Default()
+    public static MouseEventsViewModel Default()
     {
-        return new MouseClicksViewModel
+        return new MouseEventsViewModel
         {
+            HighlightForegroundColor = Color.FromArgb(0, 0, 0, 255),
             LeftButtonForegroundColor = Color.FromArgb(120, 255, 255, 0),
             RightButtonForegroundColor = Color.FromArgb(120, 255, 0, 0),
-            MiddleButtonForegroundColor = Color.FromArgb(120, 0, 255,255),
+            MiddleButtonForegroundColor = Color.FromArgb(120, 0, 255, 255),
             Height = 12,
             Width = 12
         };
     }
 
-    public static MouseClicksViewModel FromSettings()
+    public static MouseEventsViewModel FromSettings()
     {
-        return new MouseClicksViewModel
+        return new MouseEventsViewModel
         {
+            HighlightForegroundColor = UserSettings.All.MouseHighlightColor,
             LeftButtonForegroundColor = UserSettings.All.LeftMouseButtonClicksColor,
             MiddleButtonForegroundColor = UserSettings.All.MiddleMouseButtonClicksColor,
             RightButtonForegroundColor = UserSettings.All.RightMouseButtonClicksColor,
-            Height = UserSettings.All.MouseClicksHeight,
-            Width = UserSettings.All.MouseClicksWidth
+            Height = UserSettings.All.MouseEventsHeight,
+            Width = UserSettings.All.MouseEventsWidth
         };
     }
 }

--- a/ScreenToGif/Capture/DirectImageCapture.cs
+++ b/ScreenToGif/Capture/DirectImageCapture.cs
@@ -792,7 +792,7 @@ internal class DirectImageCapture : BaseCapture
             PreviousPosition = info.PointerPosition;
 
         //TODO: In a future version, don't merge the cursor image in here, let the editor do that.
-        //Saves the position of the cursor, so the editor can add the mouse clicks overlay later.
+        //Saves the position of the cursor, so the editor can add the mouse events overlay later.
         frame.CursorX = PreviousPosition.Position.X - (Left - OffsetLeft);
         frame.CursorY = PreviousPosition.Position.Y - (Top - OffsetTop);
 

--- a/ScreenToGif/Model/FrameInfo.cs
+++ b/ScreenToGif/Model/FrameInfo.cs
@@ -206,7 +206,7 @@ public class FrameInfo : IFrame
 
 
     /// <summary>
-    /// This works as a migration method for mouse clicks. Before storing the button
+    /// This works as a migration method for mouse events. Before storing the button
     /// type only bool was stored to mark the clicks. During opening old project it will
     /// be converted to Left mouse button click loosing some info unfortunately.
     /// </summary>

--- a/ScreenToGif/Resources/Commands.xaml
+++ b/ScreenToGif/Resources/Commands.xaml
@@ -297,7 +297,7 @@
         </RoutedUICommand.InputGestures>
     </RoutedUICommand>
 
-    <RoutedUICommand x:Key="Command.MouseClicks" Text="S.Command.MouseClicks">
+    <RoutedUICommand x:Key="Command.MouseEvents" Text="S.Command.MouseEvents">
         <RoutedUICommand.InputGestures>
             <KeyGesture>Alt + I</KeyGesture>
         </RoutedUICommand.InputGestures>

--- a/ScreenToGif/Resources/Localization/StringResources.en.xaml
+++ b/ScreenToGif/Resources/Localization/StringResources.en.xaml
@@ -1058,7 +1058,7 @@
     <s:String x:Key="S.Editor.Image.Overlay">Overlay</s:String>
     <s:String x:Key="S.Editor.Image.FreeDrawing">Free&#x0d;Drawing</s:String>
     <s:String x:Key="S.Editor.Image.Shape">Shapes</s:String>
-    <s:String x:Key="S.Editor.Image.Clicks">Mouse&#x0d;Clicks</s:String>
+    <s:String x:Key="S.Editor.Image.MouseEvents">Mouse&#x0d;Events</s:String>
     <s:String x:Key="S.Editor.Image.Watermark">Watermark</s:String>
     <s:String x:Key="S.Editor.Image.Cinemagraph">Cinemagraph</s:String>
     <s:String x:Key="S.Editor.Image.Border">Border</s:String>
@@ -1373,12 +1373,12 @@
     <s:String x:Key="S.Shapes.Shapes.Remove">Remove</s:String>
     <s:String x:Key="S.Shapes.Fill">Fill</s:String>
 
-    <!--Editor • Mouse clicks-->
-    <s:String x:Key="S.MouseClicks">Mouse Clicks</s:String>
+    <!--Editor • Mouse events-->
+    <s:String x:Key="S.MouseEvents">Mouse Events</s:String>
+    <s:String x:Key="S.MouseHighlight.Color">Mouse Highlight Color:</s:String>
     <s:String x:Key="S.MouseClicks.Color.Left">Left button color:</s:String>
     <s:String x:Key="S.MouseClicks.Color.Middle">Middle button color:</s:String>
     <s:String x:Key="S.MouseClicks.Color.Right">Right button color:</s:String>
-    <s:String x:Key="S.MouseClicks.Warning.None">There's no detected mouse clicks on your project.</s:String>
     
     <!--Editor • Watermark-->
     <s:String x:Key="S.Watermark.Image">Image</s:String>

--- a/ScreenToGif/Resources/Settings.xaml
+++ b/ScreenToGif/Resources/Settings.xaml
@@ -144,7 +144,7 @@
     
     <!--Options • Automated Tasks-->
     <c:ArrayList Capacity="1" x:Key="AutomatedTasksList">
-        <t:MouseClicksViewModel LeftButtonForegroundColor="#78FFFF00" RightButtonForegroundColor="#78FF0000" MiddleButtonForegroundColor="#7800FFFF" Width="12" Height="12" TaskType="MouseClicks"/>
+        <t:MouseEventsViewModel HighlightForegroundColor="#000000FF"  LeftButtonForegroundColor="#78FFFF00" RightButtonForegroundColor="#78FF0000" MiddleButtonForegroundColor="#7800FFFF" Width="12" Height="12" TaskType="MouseEvents"/>
     </c:ArrayList>
 
     <!--Options • Shortcuts-->
@@ -349,12 +349,13 @@
     <VerticalAlignment x:Key="ProgressVerticalAligment">Bottom</VerticalAlignment>
     <Orientation x:Key="ProgressOrientation">Horizontal</Orientation>
 
-    <!--Editor • Mouse Clicks-->
+    <!--Editor • Mouse Events -->
+    <Color x:Key="MouseHighlightColor">#000000FF</Color>
     <Color x:Key="LeftMouseButtonClicksColor">#78FFFF00</Color>
     <Color x:Key="MiddleMouseButtonClicksColor">#7800FFFF</Color>
     <Color x:Key="RightMouseButtonClicksColor">#78FF0000</Color>
-    <s:Double x:Key="MouseClicksWidth">12</s:Double>
-    <s:Double x:Key="MouseClicksHeight">12</s:Double>
+    <s:Double x:Key="MouseEventsWidth">12</s:Double>
+    <s:Double x:Key="MouseEventsHeight">12</s:Double>
     
     <!--Editor • Border-->
     <Color x:Key="BorderColor">#FF000000</Color>

--- a/ScreenToGif/UserControls/MouseClicksPanel.xaml
+++ b/ScreenToGif/UserControls/MouseClicksPanel.xaml
@@ -1,4 +1,4 @@
-<UserControl x:Class="ScreenToGif.UserControls.MouseClicksPanel"
+<UserControl x:Class="ScreenToGif.UserControls.MouseEventsPanel"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
@@ -20,6 +20,7 @@
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
             </Grid.RowDefinitions>
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto"/>
@@ -27,21 +28,24 @@
                 <ColumnDefinition Width="*"/>
             </Grid.ColumnDefinitions>
 
-            <TextBlock Grid.Row="0" Grid.Column="0" Text="{DynamicResource S.MouseClicks.Color.Left}" VerticalAlignment="Center" Foreground="{DynamicResource Element.Foreground.Medium}"/>
-            <n:ColorBox Grid.Row="0" Grid.Column="1" SelectedColor="{Binding LeftButtonForegroundColor, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Margin="10,5"/>
+            <TextBlock Grid.Row="0" Grid.Column="0" Text="{DynamicResource S.MouseHighlight.Color}" VerticalAlignment="Center" Foreground="{DynamicResource Element.Foreground.Medium}"/>
+            <n:ColorBox Grid.Row="0" Grid.Column="1" SelectedColor="{Binding HighlightForegroundColor, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Margin="10,5"/>
+            
+            <TextBlock Grid.Row="1" Grid.Column="0" Text="{DynamicResource S.MouseClicks.Color.Left}" VerticalAlignment="Center" Foreground="{DynamicResource Element.Foreground.Medium}"/>
+            <n:ColorBox Grid.Row="1" Grid.Column="1" SelectedColor="{Binding LeftButtonForegroundColor, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Margin="10,5"/>
 
-            <TextBlock Grid.Row="1" Grid.Column="0" Text="{DynamicResource S.MouseClicks.Color.Middle}" VerticalAlignment="Center" Foreground="{DynamicResource Element.Foreground.Medium}"/>
-            <n:ColorBox Grid.Row="1" Grid.Column="1" SelectedColor="{Binding MiddleButtonForegroundColor, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Margin="10,5"/>
+            <TextBlock Grid.Row="2" Grid.Column="0" Text="{DynamicResource S.MouseClicks.Color.Middle}" VerticalAlignment="Center" Foreground="{DynamicResource Element.Foreground.Medium}"/>
+            <n:ColorBox Grid.Row="2" Grid.Column="1" SelectedColor="{Binding MiddleButtonForegroundColor, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Margin="10,5"/>
 
-            <TextBlock Grid.Row="2" Grid.Column="0" Text="{DynamicResource S.MouseClicks.Color.Right}" VerticalAlignment="Center" Foreground="{DynamicResource Element.Foreground.Medium}"/>
-            <n:ColorBox Grid.Row="2" Grid.Column="1" SelectedColor="{Binding RightButtonForegroundColor, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Margin="10,5"/>
+            <TextBlock Grid.Row="3" Grid.Column="0" Text="{DynamicResource S.MouseClicks.Color.Right}" VerticalAlignment="Center" Foreground="{DynamicResource Element.Foreground.Medium}"/>
+            <n:ColorBox Grid.Row="3" Grid.Column="1" SelectedColor="{Binding RightButtonForegroundColor, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Margin="10,5"/>
 
-            <TextBlock Grid.Row="3" Grid.Column="0" Text="{DynamicResource S.FreeDrawing.Width}" VerticalAlignment="Center" Foreground="{DynamicResource Element.Foreground.Medium}"/>
-            <n:DoubleUpDown Grid.Row="3" Grid.Column="1" x:Name="ClickWidthDoubleUpDown" Minimum="1" Maximum="1000" Margin="10,5" MinWidth="70"
+            <TextBlock Grid.Row="4" Grid.Column="0" Text="{DynamicResource S.FreeDrawing.Width}" VerticalAlignment="Center" Foreground="{DynamicResource Element.Foreground.Medium}"/>
+            <n:DoubleUpDown Grid.Row="4" Grid.Column="1" x:Name="ClickWidthDoubleUpDown" Minimum="1" Maximum="1000" Margin="10,5" MinWidth="70"
                             Value="{Binding Width, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
 
-            <TextBlock Grid.Row="4" Grid.Column="0" Text="{DynamicResource S.FreeDrawing.Height}" VerticalAlignment="Center" Foreground="{DynamicResource Element.Foreground.Medium}"/>
-            <n:DoubleUpDown Grid.Row="4" Grid.Column="1" x:Name="ClickHeightDoubleUpDown" Minimum="1" Maximum="1000" Margin="10,5" MinWidth="70"
+            <TextBlock Grid.Row="5" Grid.Column="0" Text="{DynamicResource S.FreeDrawing.Height}" VerticalAlignment="Center" Foreground="{DynamicResource Element.Foreground.Medium}"/>
+            <n:DoubleUpDown Grid.Row="5" Grid.Column="1" x:Name="ClickHeightDoubleUpDown" Minimum="1" Maximum="1000" Margin="10,5" MinWidth="70"
                             Value="{Binding Height, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
         </Grid>
     </Grid>

--- a/ScreenToGif/UserControls/MouseClicksPanel.xaml.cs
+++ b/ScreenToGif/UserControls/MouseClicksPanel.xaml.cs
@@ -2,9 +2,9 @@ using System.Windows.Controls;
 
 namespace ScreenToGif.UserControls;
 
-public partial class MouseClicksPanel : UserControl
+public partial class MouseEventsPanel : UserControl
 {
-    public MouseClicksPanel()
+    public MouseEventsPanel()
     {
         InitializeComponent();
     }

--- a/ScreenToGif/Windows/Editor.xaml
+++ b/ScreenToGif/Windows/Editor.xaml
@@ -289,7 +289,7 @@
 
         <CommandBinding Command="{StaticResource Command.FreeDrawing}" CanExecute="Image_CanExecute" Executed="FreeDrawing_Executed"/>
         <CommandBinding Command="{StaticResource Command.Shapes}" CanExecute="Image_CanExecute" Executed="Shapes_Executed"/>
-        <CommandBinding Command="{StaticResource Command.MouseClicks}" CanExecute="Image_CanExecute" Executed="MouseClicks_Executed"/>
+        <CommandBinding Command="{StaticResource Command.MouseEvents}" CanExecute="Image_CanExecute" Executed="MouseEvents_Executed"/>
         <CommandBinding Command="{StaticResource Command.Watermark}" CanExecute="Image_CanExecute" Executed="Watermark_Executed"/>
         <CommandBinding Command="{StaticResource Command.Border}" CanExecute="Image_CanExecute" Executed="Border_Executed"/>
         <CommandBinding Command="{StaticResource Command.Shadow}" CanExecute="Image_CanExecute" Executed="Shadow_Executed"/>
@@ -1125,8 +1125,8 @@
                                           ToolTip="{Binding Command, RelativeSource={RelativeSource Self}, Converter={StaticResource CommandToInputGestureText}}" 
                                           ToolTipService.Placement="Bottom" ToolTipService.HorizontalOffset="-5"/>
 
-                        <n:ExtendedButton Grid.Row="0" Grid.Column="3" Text="{DynamicResource S.Editor.Image.Clicks}" Icon="{StaticResource Vector.Cursor}"
-                                          MinWidth="55" ContentHeight="28" ContentWidth="32" Command="{StaticResource Command.MouseClicks}" Style="{StaticResource Style.Button.Vertical}"
+                        <n:ExtendedButton Grid.Row="0" Grid.Column="3" Text="{DynamicResource S.Editor.Image.MouseEvents}" Icon="{StaticResource Vector.Cursor}"
+                                          MinWidth="55" ContentHeight="28" ContentWidth="32" Command="{StaticResource Command.MouseEvents}" Style="{StaticResource Style.Button.Vertical}"
                                           ToolTip="{Binding Command, RelativeSource={RelativeSource Self}, Converter={StaticResource CommandToInputGestureText}}" 
                                           ToolTipService.Placement="Bottom" ToolTipService.HorizontalOffset="-5"/>
 
@@ -2897,7 +2897,7 @@
                             </Grid>
                         </Grid>
 
-                        <Grid x:Name="MouseClicksGrid" Visibility="Collapsed">
+                        <Grid x:Name="MouseEventsGrid" Visibility="Collapsed">
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="27"/>
                                 <RowDefinition Height="Auto"/>
@@ -2908,6 +2908,7 @@
                             <n:LabelSeparator Grid.Row="0" Text="{DynamicResource S.Border.Appearance}"/>
                             <Grid Grid.Row="1" Margin="10,0,0,0">
                                 <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto"/>
                                     <RowDefinition Height="Auto"/>
                                     <RowDefinition Height="Auto"/>
                                     <RowDefinition Height="Auto"/>
@@ -2948,40 +2949,44 @@
                                     <TextBlock Text="Rectangle" Tag="{StaticResource Vector.Rectangle}"/>
                                 </ComboBox>-->
 
-                                <TextBlock Grid.Row="1" Grid.Column="0" Text="{DynamicResource S.MouseClicks.Color.Left}" VerticalAlignment="Center" Foreground="{DynamicResource Element.Foreground.Medium}"/>
-                                <n:ColorBox Grid.Row="1" Grid.Column="1" x:Name="LeftButtonClickColor" Margin="10,5"
+                                <TextBlock Grid.Row="1" Grid.Column="0" Text="{DynamicResource S.MouseHighlight.Color}" VerticalAlignment="Center" Foreground="{DynamicResource Element.Foreground.Medium}"/>
+                                <n:ColorBox Grid.Row="1" Grid.Column="1" x:Name="MouseHighlightColor" Margin="10,5"
+                                            SelectedColor="{Binding Source={x:Static t:UserSettings.All}, Path=MouseHighlightColor, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+
+                                <TextBlock Grid.Row="2" Grid.Column="0" Text="{DynamicResource S.MouseClicks.Color.Left}" VerticalAlignment="Center" Foreground="{DynamicResource Element.Foreground.Medium}"/>
+                                <n:ColorBox Grid.Row="2" Grid.Column="1" x:Name="LeftButtonClickColor" Margin="10,5"
                                             SelectedColor="{Binding Source={x:Static t:UserSettings.All}, Path=LeftMouseButtonClicksColor, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
 
-                                <TextBlock Grid.Row="2" Grid.Column="0" Text="{DynamicResource S.MouseClicks.Color.Middle}" VerticalAlignment="Center" Foreground="{DynamicResource Element.Foreground.Medium}"/>
-                                <n:ColorBox Grid.Row="2" Grid.Column="1" x:Name="MiddleButtonClickColor" Margin="10,5"
+                                <TextBlock Grid.Row="3" Grid.Column="0" Text="{DynamicResource S.MouseClicks.Color.Middle}" VerticalAlignment="Center" Foreground="{DynamicResource Element.Foreground.Medium}"/>
+                                <n:ColorBox Grid.Row="3" Grid.Column="1" x:Name="MiddleButtonClickColor" Margin="10,5"
                                             SelectedColor="{Binding Source={x:Static t:UserSettings.All}, Path=MiddleMouseButtonClicksColor, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
 
-                                <TextBlock Grid.Row="3" Grid.Column="0" Text="{DynamicResource S.MouseClicks.Color.Right}" VerticalAlignment="Center" Foreground="{DynamicResource Element.Foreground.Medium}"/>
-                                <n:ColorBox Grid.Row="3" Grid.Column="1" x:Name="RightButtonClickColor" Margin="10,5"
+                                <TextBlock Grid.Row="4" Grid.Column="0" Text="{DynamicResource S.MouseClicks.Color.Right}" VerticalAlignment="Center" Foreground="{DynamicResource Element.Foreground.Medium}"/>
+                                <n:ColorBox Grid.Row="4" Grid.Column="1" x:Name="RightButtonClickColor" Margin="10,5"
                                             SelectedColor="{Binding Source={x:Static t:UserSettings.All}, Path=RightMouseButtonClicksColor, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
 
-                                <TextBlock Grid.Row="4" Grid.Column="0" Text="{DynamicResource S.FreeDrawing.Width}" VerticalAlignment="Center" Foreground="{DynamicResource Element.Foreground.Medium}"/>
-                                <n:DoubleUpDown Grid.Row="4" Grid.Column="1" x:Name="ClickWidthDoubleUpDown" Minimum="1" Maximum="1000" Margin="10,5" MinWidth="70"
-                                                Value="{Binding Source={x:Static t:UserSettings.All}, Path=MouseClicksWidth, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+                                <TextBlock Grid.Row="5" Grid.Column="0" Text="{DynamicResource S.FreeDrawing.Width}" VerticalAlignment="Center" Foreground="{DynamicResource Element.Foreground.Medium}"/>
+                                <n:DoubleUpDown Grid.Row="5" Grid.Column="1" x:Name="ClickWidthDoubleUpDown" Minimum="1" Maximum="1000" Margin="10,5" MinWidth="70"
+                                                Value="{Binding Source={x:Static t:UserSettings.All}, Path=MouseEventsWidth, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
 
-                                <TextBlock Grid.Row="5" Grid.Column="0" Text="{DynamicResource S.FreeDrawing.Height}" VerticalAlignment="Center" Foreground="{DynamicResource Element.Foreground.Medium}"/>
-                                <n:DoubleUpDown Grid.Row="5" Grid.Column="1" x:Name="ClickHeightDoubleUpDown" Minimum="1" Maximum="1000" Margin="10,5" MinWidth="70"
-                                                Value="{Binding Source={x:Static t:UserSettings.All}, Path=MouseClicksHeight, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+                                <TextBlock Grid.Row="6" Grid.Column="0" Text="{DynamicResource S.FreeDrawing.Height}" VerticalAlignment="Center" Foreground="{DynamicResource Element.Foreground.Medium}"/>
+                                <n:DoubleUpDown Grid.Row="6" Grid.Column="1" x:Name="ClickHeightDoubleUpDown" Minimum="1" Maximum="1000" Margin="10,5" MinWidth="70"
+                                                Value="{Binding Source={x:Static t:UserSettings.All}, Path=MouseEventsHeight, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
                             </Grid>
                             <!--<n:LabelSeparator Grid.Row="2" Text="{DynamicResource S.Preview}"/>
                             <Grid Grid.Row="3" x:Name="PreviewGrid" Margin="10,5">
                                 <Viewbox x:Name="PreviewViewBox" Child="{StaticResource Vector.Cursor}" Height="20" Width="20" Stretch="Uniform">
                                     <Viewbox.Margin>
                                         <MultiBinding Converter="{StaticResource DoubleToThicknessConverter}">
-                                            <Binding Source="{x:Static t:UserSettings.All}" Path="MouseClicksWidth"/>
-                                            <Binding Source="{x:Static t:UserSettings.All}" Path="MouseClicksHeight"/>
+                                            <Binding Source="{x:Static t:UserSettings.All}" Path="MouseEventsWidth"/>
+                                            <Binding Source="{x:Static t:UserSettings.All}" Path="MouseEventsHeight"/>
                                         </MultiBinding>
                                     </Viewbox.Margin>
                                 </Viewbox>
 
                                 <Ellipse Fill="{Binding ElementName=MouseBackgroundColor, Path=SelectedBrush, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"
-                                         Width="{Binding Source={x:Static t:UserSettings.All}, Path=MouseClicksWidth, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"
-                                         Height="{Binding Source={x:Static t:UserSettings.All}, Path=MouseClicksHeight, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"
+                                         Width="{Binding Source={x:Static t:UserSettings.All}, Path=MouseEventsWidth, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"
+                                         Height="{Binding Source={x:Static t:UserSettings.All}, Path=MouseEventsHeight, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"
                                          HorizontalAlignment="Center" VerticalAlignment="Center" Stretch="None"/>
                             </Grid>-->
                         </Grid>

--- a/ScreenToGif/Windows/Other/AutomatedTask.xaml
+++ b/ScreenToGif/Windows/Other/AutomatedTask.xaml
@@ -73,7 +73,7 @@
                 </u:ComboBoxItemTemplateSelector.DropDownTemplate>
 
                 <t:BaseTaskViewModel Image="Vector.Info"/>
-                <t:MouseClicksViewModel Image="Vector.Cursor"/>
+                <t:MouseEventsViewModel Image="Vector.Cursor"/>
                 <t:KeyStrokesViewModel Image="Vector.Keyboard"/>
                 <t:DelayViewModel Image="Vector.Clock"/>
                 <t:ProgressViewModel Image="Vector.Progress"/>

--- a/ScreenToGif/Windows/Other/AutomatedTask.xaml.cs
+++ b/ScreenToGif/Windows/Other/AutomatedTask.xaml.cs
@@ -51,8 +51,8 @@ public partial class AutomatedTask : Window
             //Create a new model.
             switch ((TaskTypes)TypeComboBox.SelectedIndex)
             {
-                case TaskTypes.MouseClicks:
-                    CurrentTask = MouseClicksViewModel.Default();
+                case TaskTypes.MouseEvents:
+                    CurrentTask = MouseEventsViewModel.Default();
                     break;
                 case TaskTypes.KeyStrokes:
                     CurrentTask = KeyStrokesViewModel.Default();
@@ -74,8 +74,8 @@ public partial class AutomatedTask : Window
 
         switch ((TaskTypes)TypeComboBox.SelectedIndex)
         {
-            case TaskTypes.MouseClicks:
-                MainPresenter.Content = new MouseClicksPanel { DataContext = CurrentTask };
+            case TaskTypes.MouseEvents:
+                MainPresenter.Content = new MouseEventsPanel { DataContext = CurrentTask };
                 break;
             case TaskTypes.KeyStrokes:
                 MainPresenter.Content = new KeyStrokesPanel { DataContext = CurrentTask };


### PR DESCRIPTION
Hi!

This is a small change to the "Mouse Clicks" overlay feature: Adds a new setting to highlight the mouse cursor without clicks.
The name "Mouse Clicks" didn't seem appropriate anymore, so it's also renamed to "Mouse Events".

The highlight color is fully transparent by default, so it's not visible, and added a check to skip drawing transparent mouse overlays.

This is my first pull request, so I hope it's ok. :) Wasn't sure of the migrations part and what to do about the localization files.
Here are some screenshots:
![image](https://user-images.githubusercontent.com/4281365/148661427-be287eb0-d77f-42b8-a5aa-f7d62b5eca66.png)
![image](https://user-images.githubusercontent.com/4281365/148661450-2760c7c1-2d97-4c92-a800-8a964295e723.png)

closes #1086