### PR TITLE
Show hours if duration is greater than or equal to 60 minutes

### DIFF
--- a/ScreenToGif.Util/Converters/TimeSpanToString.cs
+++ b/ScreenToGif.Util/Converters/TimeSpanToString.cs
@@ -1,0 +1,31 @@
+using System.Globalization;
+using System.Windows.Data;
+
+namespace ScreenToGif.Util.Converters;
+
+public class TimeSpanToString : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (value is not TimeSpan time)
+            return Binding.DoNothing;
+
+        if (time.Days > 0)
+        {
+            return time.ToString("d\\:hh\\:mm\\:ss", culture);
+        }
+        else if (time.Hours > 0)
+        {
+            return time.ToString("h\\:mm\\:ss", culture);
+        }
+        else
+        {
+            return time.ToString("mm\\:ss", culture);
+        }
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        return Binding.DoNothing;
+    }
+}

--- a/ScreenToGif/Themes/Generic.xaml
+++ b/ScreenToGif/Themes/Generic.xaml
@@ -35,6 +35,7 @@
     <c:IntToBool x:Key="IntToBool"/>
     <c:EnumToBool x:Key="EnumToBool"/>
     <c:TimeSpanToTotalMilliseconds x:Key="TimeSpanToTotalMilliseconds"/>
+    <c:TimeSpanToString x:Key="TimeSpanToString"/>
 
     <!--Window Style -->
     <Style TargetType="{x:Type n:LightWindow}">
@@ -3190,7 +3191,7 @@
                             <Border Grid.Column="1" x:Name="PauseBorder" Background="{DynamicResource Vector.Pause.Color}" Height="12" Width="0" VerticalAlignment="Center" HorizontalAlignment="Center"/>
 
                             <TextBlock Grid.Column="2" x:Name="NegativeTextBlock" FontSize="14" Padding="0" Margin="0" Text="-" Visibility="Collapsed"/>
-                            <TextBlock Grid.Column="3" x:Name="ElapsedTextBlock" FontSize="14" Padding="0" Margin="0" Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Elapsed, StringFormat={}{0:mm\\:ss}}"/>
+                            <TextBlock Grid.Column="3" x:Name="ElapsedTextBlock" FontSize="14" Padding="0" Margin="0" Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Elapsed, Converter={StaticResource TimeSpanToString}}"/>
 
                             <TextBlock Grid.Column="4" x:Name="ManualTextBlock" FontSize="14" Padding="0" Margin="2,0,0,0" Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=ManuallyCapturedCount, StringFormat={}+{0:0}}"/>
                         </Grid>


### PR DESCRIPTION
Fixes #1084.

The number of days in a TimeSpan cannot be optionally shown just by using a forma string, so I've created an `IValueConverter` to format the duration.

Seconds:
![image](https://user-images.githubusercontent.com/10321525/156905353-5d7dda1d-b720-4c56-8b46-ddf57a031884.png)

Minutes:
![image](https://user-images.githubusercontent.com/10321525/156905349-8bdfc95d-2cb3-4e29-b25e-9793401c224d.png)

![image](https://user-images.githubusercontent.com/10321525/156905341-4f83b3ba-d66b-4f52-a319-8c53c42ff0a6.png)

Hours:
![image](https://user-images.githubusercontent.com/10321525/156905335-675e4356-bf72-4a16-8df1-101e658ac8e2.png)

![image](https://user-images.githubusercontent.com/10321525/156905325-f76d88aa-6dca-4100-9f51-c3fc4f8fcaa8.png)


Days:
![image](https://user-images.githubusercontent.com/10321525/156905318-73016ccb-425d-4af1-b9e0-335a1681a7fd.png)

