### PR TITLE
Added trigger delay option for after interaction snap fires

### DIFF
--- a/ScreenToGif.Util/Settings/UserSettings.cs
+++ b/ScreenToGif.Util/Settings/UserSettings.cs
@@ -1177,6 +1177,15 @@ public class UserSettings : INotifyPropertyChanged
         get => (int)GetValue();
         set => SetValue(value);
     }
+    /// <summary>
+    /// The delay after trigger speed of the capture frame, in the "interaction" mode.
+    /// </summary>
+    public int TriggerDelayInteraction
+    {
+        get => (int)GetValue();
+        set => SetValue(value);
+    }
+    
 
     /// <summary>
     /// The placyback speed of the capture frame, in the "per minute" mode.

--- a/ScreenToGif/Controls/BaseScreenRecorder.cs
+++ b/ScreenToGif/Controls/BaseScreenRecorder.cs
@@ -79,6 +79,16 @@ public class BaseScreenRecorder : BaseRecorder
                 return 1000 / UserSettings.All.LatestFps;
         }
     }
+    internal int GetTriggerDelay()
+    {
+        switch (UserSettings.All.CaptureFrequency)
+        {
+            case CaptureFrequencies.Interaction:
+                return UserSettings.All.TriggerDelayInteraction;
+            default:
+                return 0;
+        }
+    }
 
     internal int GetCaptureInterval()
     {

--- a/ScreenToGif/Resources/Localization/StringResources.en.xaml
+++ b/ScreenToGif/Resources/Localization/StringResources.en.xaml
@@ -280,6 +280,8 @@
     <s:String x:Key="S.Options.Recorder.Frequency.Hour.Info">Frames will be captured in a 'per hour' basis (timelapse),&#10;given the framerate denominator set on the recorder screen.</s:String>
     <s:String x:Key="S.Options.Recorder.Frequency.Playback">Playback delay:</s:String>
     <s:String x:Key="S.Options.Recorder.Frequency.Playback.Info">(In ms, each captured frame will be set to this delay)</s:String>
+    <s:String x:Key="S.Options.Recorder.Frequency.Trigger">Trigger delay:</s:String>
+    <s:String x:Key="S.Options.Recorder.Frequency.Trigger.Info">(In ms, each trigged captured fram will wait this long after trigger before capture)</s:String>
     <s:String x:Key="S.Options.Recorder.Frequency.Interval">Each frame will be captured in interval of {0}.</s:String>
     
     <s:String x:Key="S.Options.Recorder.Mode">Capture mode</s:String>

--- a/ScreenToGif/Resources/Settings.xaml
+++ b/ScreenToGif/Resources/Settings.xaml
@@ -84,6 +84,7 @@
     <e:CaptureFrequencies x:Key="CaptureFrequency">PerSecond</e:CaptureFrequencies>
     <s:Int32 x:Key="PlaybackDelayManual">1000</s:Int32>
     <s:Int32 x:Key="PlaybackDelayInteraction">500</s:Int32>
+    <s:Int32 x:Key="TriggerDelayInteraction">0</s:Int32>
     <s:Int32 x:Key="PlaybackDelayMinute">66</s:Int32>
     <s:Int32 x:Key="PlaybackDelayHour">66</s:Int32>
     <s:Boolean x:Key="FixedFrameRate">False</s:Boolean>

--- a/ScreenToGif/Windows/NewRecorder.xaml.cs
+++ b/ScreenToGif/Windows/NewRecorder.xaml.cs
@@ -1138,6 +1138,9 @@ public partial class NewRecorder
 
     private async Task Snap()
     {
+        var snapTriggerDelay = GetTriggerDelay();
+        if (snapTriggerDelay != 0)
+            await Task.Delay(snapTriggerDelay);
         #region If region not yet selected
 
         if (_viewModel.Region.IsEmpty)

--- a/ScreenToGif/Windows/Options.xaml
+++ b/ScreenToGif/Windows/Options.xaml
@@ -507,6 +507,11 @@
                                     <n:IntegerUpDown Minimum="10" Maximum="25000" Value="{Binding Path=PlaybackDelayHour, Mode=TwoWay}" MinWidth="80" Visibility="{Binding ElementName=PerHourRadioButton, Path=IsChecked, Mode=OneWay, Converter={StaticResource Bool2Visibility}}"/>
                                     <TextBlock Text="{DynamicResource S.Options.Recorder.Frequency.Playback.Info}" Padding="0" Margin="5,0,0,0" VerticalAlignment="Center" TextWrapping="WrapWithOverflow" Foreground="{DynamicResource Element.Foreground.Gray150}"/>
                                 </WrapPanel>
+                                <WrapPanel Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="7" Visibility="{Binding ElementName=InteractionRadioButton, Path=IsChecked, Mode=OneWay, Converter={StaticResource Bool2Visibility}, FallbackValue=Collapsed}">
+                                    <TextBlock Text="{DynamicResource S.Options.Recorder.Frequency.Trigger}" Foreground="{DynamicResource Element.Foreground.Medium}" Padding="5,0" VerticalAlignment="Center"/>
+                                    <n:IntegerUpDown Minimum="0" Maximum="25000" Value="{Binding Path=TriggerDelayInteraction, Mode=TwoWay}" MinWidth="80" />
+                                    <TextBlock Text="{DynamicResource S.Options.Recorder.Frequency.Trigger.Info}" Padding="0" Margin="5,0,0,0" VerticalAlignment="Center" TextWrapping="WrapWithOverflow" Foreground="{DynamicResource Element.Foreground.Gray150}"/>
+                                </WrapPanel>
 
                                 <n:ExtendedCheckBox Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="7" Text="{DynamicResource S.Options.Recorder.FixedFramerate}" 
                                                     Info="{DynamicResource S.Options.Recorder.FixedFramerate.Info}" Margin="5,3" VerticalAlignment="Top" IsChecked="{Binding Path=FixedFrameRate, Mode=TwoWay}"

--- a/ScreenToGif/Windows/Recorder.xaml.cs
+++ b/ScreenToGif/Windows/Recorder.xaml.cs
@@ -960,6 +960,10 @@ public partial class Recorder
     /// </summary>
     private async Task Snap()
     {
+        var snapTriggerDelay = GetTriggerDelay();
+        if (snapTriggerDelay != 0)
+            await Task.Delay(snapTriggerDelay);
+
         HideGuidelines();
 
         if (Project == null || Project.Frames.Count == 0)


### PR DESCRIPTION
This gives the option to wait X ms after it would normally snap a frame to do the frame capture.  Could be useful if you are waiting for a menu to load, or tooltip, etc.

Closes #1101