### PR TITLE
Removes 'key translation' when getting key text

### DIFF
--- a/ScreenToGif.Native/Helpers/Other.cs
+++ b/ScreenToGif.Native/Helpers/Other.cs
@@ -40,7 +40,7 @@ public class Other
 
         Gdi32.PatBlt(hdc, rect.Right, rect.Bottom - frameWidth, -(rect.Right - rect.Left), frameWidth, Constants.DstInvert);
     }
-        
+
     internal static string CheckAllFlags(uint style, bool isExtended)
     {
         var values = Enum.GetValues(typeof(WindowStyles)).OfType<WindowStyles>().Distinct().ToList();
@@ -55,7 +55,7 @@ public class Other
 
         return text.TrimEnd(' ').TrimEnd(',');
     }
-        
+
     public static char? GetCharFromKey(Key key, bool ignoreState = true)
     {
         var virtualKey = KeyInterop.VirtualKeyFromKey(key);
@@ -71,7 +71,6 @@ public class Other
 
         switch (result)
         {
-            case -1:
             case 0:
                 break;
             default: //Case 1
@@ -83,32 +82,6 @@ public class Other
 
     public static string GetSelectKeyText(Key key, ModifierKeys modifier = ModifierKeys.None, bool isUppercase = false, bool ignoreNone = false)
     {
-        //Key translation.
-        switch (key)
-        {
-            case Key.Oem1:
-                key = Key.OemSemicolon;
-                break;
-            case Key.Oem2:
-                key = Key.OemQuestion;
-                break;
-            case Key.Oem3:
-                key = Key.OemTilde;
-                break;
-            case Key.Oem4:
-                key = Key.OemOpenBrackets;
-                break;
-            case Key.Oem5:
-                key = Key.OemPipe;
-                break;
-            case Key.Oem6:
-                key = Key.OemCloseBrackets;
-                break;
-            case Key.Oem7:
-                key = Key.OemComma;
-                break;
-        }
-
         if (ignoreNone && key == Key.None)
             return "";
 
@@ -226,7 +199,7 @@ public class Other
 
         return modifiersText;
     }
-        
+
     public static Point GetMousePosition(double scale = 1, double offsetX = 0, double offsetY = 0)
     {
         var point = new PointW();


### PR DESCRIPTION
This PR removes the "key translation" that is done when obtaining the key text. 

I guess this translation was needed because `-1` was considered an invalid result from the `ToUnicode` API (in the `GetCharFromKey` method). However, this result represents dead keys - which looks like the root of the problem here - and should be considered valid. It says that a dead key was pressed and the spacing version of that dead key was written to the output buffer, ie it'll write `~` even with just one click (in an ABNT2 Portuguese keyboard). 

[Here's the section of the documentation that explains the possible results](https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-tounicode#return-value).

This fixes #1122 

The problem in this issue is specific to one specific case in this translation tho. The OEM 7 key is a quote in the US standard keyboard layout, but it's translated to a comma.

_File: Other.cs_
```csharp
switch (key)
{ 
    case Key.Oem7:
        key = Key.OemComma;
        break;
}
```

I thought it would be better to fix it to make it work in all keyboard layouts.

I didn't write any unit tests because I couldn't think of any way of doing that without changing the OS keyboard layout. 