### PR TITLE
Add references to the website/installer localization docs

### DIFF
--- a/LOCALIZATION.md
+++ b/LOCALIZATION.md
@@ -13,7 +13,10 @@ As this project always are moving forward, new strings get added from time to ti
 
 Use the [Translator](https://github.com/NickeManarin/ScreenToGif/tree/master/Other/Translator) application to help you.
 
-You can get more information on the [wiki](https://github.com/NickeManarin/ScreenToGif/wiki/Localization).
+You can get more information on the wiki:
+- [Translating the App](https://github.com/NickeManarin/ScreenToGif/wiki/Localization)
+- [Translating the Installer](https://github.com/NickeManarin/ScreenToGif/wiki/Localization-%28Installer%29)
+- [Translating the Website](https://github.com/NickeManarin/ScreenToGif/wiki/Localization-%28Website%29)
 
 ## Creating a new language
 If you want to begin translating ScreenToGif for a new language, create a new file in the ``./Resources/Localization`` directory with the correct two letter [language](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes#Partial_ISO_639_table) and [country codes](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Decoding_table) (e.g. `es-AR`), then paste the contents of the ScreenToGif's base language file into it and start translating the strings.


### PR DESCRIPTION
The [README.md](https://github.com/NickeManarin/ScreenToGif/blob/c734573a10d1f72c54e0dd0db81018687bcce25b/README.md?plain=1#L68) refers to the `LOCALIZATION.md` as the documentation to the app/website/installer localization:

> [Anyone can still contribute to the localization of the app/website/installer](https://github.com/NickeManarin/ScreenToGif/blob/master/LOCALIZATION.md)

But that file currently contains info only about the "app" part.

This PR adds links to the website/installer localization wiki pages to that file.