### PR TITLE
Add minimal AV1 support for MP4 container

### DIFF
--- a/ScreenToGif/UserControls/ExportPanel.xaml.cs
+++ b/ScreenToGif/UserControls/ExportPanel.xaml.cs
@@ -580,7 +580,6 @@ public partial class ExportPanel : UserControl, IPanel
                 break;
             }
             case ExportFormats.Mov:
-            case ExportFormats.Mp4:
             {
                 if (videoPreset.HardwareAcceleration == HardwareAccelerationModes.On)
                 {
@@ -602,6 +601,39 @@ public partial class ExportPanel : UserControl, IPanel
                     {
                         new X264(),
                         new X265()
+                    };
+                }
+
+                break;
+            }
+            case ExportFormats.Mp4:
+            {
+                if (videoPreset.HardwareAcceleration == HardwareAccelerationModes.On)
+                {
+                    FfmpegCodecComboBox.ItemsSource = new List<VideoCodec>
+                    {
+                        new X264(),
+                        new H264Amf(),
+                        new H264Nvenc(),
+                        new H264Qsv(),
+                        new X265(),
+                        new HevcAmf(),
+                        new HevcNvenc(),
+                        new HevcQsv(),
+                        new LibAom(),
+                        new SvtAv1(),
+                        new Rav1E()
+                    };
+                }
+                else
+                {
+                    FfmpegCodecComboBox.ItemsSource = new List<VideoCodec>
+                    {
+                        new X264(),
+                        new X265(),
+                        new LibAom(),
+                        new SvtAv1(),
+                        new Rav1E()
                     };
                 }
 


### PR DESCRIPTION
#1193 

Just added the following AV1 codecs to MP4 options.
![image](https://user-images.githubusercontent.com/12870451/235360690-53ed6a90-5d87-4ffd-b55a-474442cc0a01.png)

The following examples are created by this program with my patch, and can be played using other than Safari and Edge without the AV1 video extension.

- https://caniuse.com/av1
- https://tests.caniuse.com/av1

SVT-AV1

https://user-images.githubusercontent.com/12870451/235360577-d5514eef-3cfc-4247-ad5c-5f32e2f3a4c4.mp4

AOM

https://user-images.githubusercontent.com/12870451/235360901-41b42f07-66c0-4212-b7f8-b4564e3191b8.mp4

Rav1E

https://user-images.githubusercontent.com/12870451/235360908-0cef7a5f-3a73-4009-be67-304a88f9d448.mp4
