### PR TITLE
Fix "Mouse Events" button tooltip

### DIFF
--- a/ScreenToGif/Resources/Localization/StringResources.ar.xaml
+++ b/ScreenToGif/Resources/Localization/StringResources.ar.xaml
@@ -99,7 +99,7 @@
     <s:String x:Key="S.Command.KeyStrokes">ادراج المفاتيح التي تم الضغط عليها اثناء التسجيل</s:String>
     <s:String x:Key="S.Command.FreeDrawing">رسم اشكال حره</s:String>
     <s:String x:Key="S.Command.Shapes">اضافه اشكال</s:String>
-    <s:String x:Key="S.Command.MouseClicks">نقرات الماوس</s:String>
+    <s:String x:Key="S.Command.MouseEvents">نقرات الماوس</s:String>
     <s:String x:Key="S.Command.Watermark">تحديد صوره واضافها باسم علامة مائية</s:String>
     <s:String x:Key="S.Command.Border">اضافه حدود</s:String>
     <s:String x:Key="S.Command.Shadow">اضافه ظل مسقط</s:String>
@@ -1145,7 +1145,7 @@
     <s:String x:Key="S.Shapes.Fill">ملء</s:String>
 
     <!--Editor • Mouse clicks-->
-    <s:String x:Key="S.MouseClicks">نقرات الماوس</s:String>
+    <s:String x:Key="S.MouseEvents">نقرات الماوس</s:String>
     <s:String x:Key="S.MouseClicks.Warning.None">لا يوجد نقرات الماوس الكشف عن مشروعك.</s:String>
     
     <!--Editor • Watermark-->

--- a/ScreenToGif/Resources/Localization/StringResources.cs.xaml
+++ b/ScreenToGif/Resources/Localization/StringResources.cs.xaml
@@ -99,7 +99,7 @@
     <!--<s:String x:Key="S.Command.KeyStrokes">Inserts keys pressed during the recording</s:String>-->
     <!--<s:String x:Key="S.Command.FreeDrawing">Draw free forms</s:String>-->
     <!--<s:String x:Key="S.Command.Shapes">Add shapes</s:String>-->
-    <!--<s:String x:Key="S.Command.MouseClicks">Mouse clicks</s:String>-->
+    <!--<s:String x:Key="S.Command.MouseEvents">Mouse clicks</s:String>-->
     <!--<s:String x:Key="S.Command.Watermark">Select an image and add as watermark</s:String>-->
     <!--<s:String x:Key="S.Command.Border">Add borders</s:String>-->
     <!--<s:String x:Key="S.Command.Shadow">Add drop shadow</s:String>-->
@@ -1145,7 +1145,7 @@
     <!--<s:String x:Key="S.Shapes.Fill">Fill</s:String>-->
 
     <!--Editor • Mouse clicks-->
-    <!--<s:String x:Key="S.MouseClicks">Mouse Clicks</s:String>-->
+    <!--<s:String x:Key="S.MouseEvents">Mouse Clicks</s:String>-->
     <!--<s:String x:Key="S.MouseClicks.Warning.None">There's no detected mouse clicks on your project.</s:String>-->
     
     <!--Editor • Watermark-->

--- a/ScreenToGif/Resources/Localization/StringResources.da.xaml
+++ b/ScreenToGif/Resources/Localization/StringResources.da.xaml
@@ -123,7 +123,7 @@
     <s:String x:Key="S.Command.KeyStrokes">Indsætter optagne tastetryk</s:String>
     <s:String x:Key="S.Command.FreeDrawing">Tegn frit</s:String>
     <s:String x:Key="S.Command.Shapes">Tilføj figurer</s:String>
-    <s:String x:Key="S.Command.MouseClicks">Museklik</s:String>
+    <s:String x:Key="S.Command.MouseEvents">Museklik</s:String>
     <s:String x:Key="S.Command.Watermark">Vælg billede til vandmærke</s:String>
     <s:String x:Key="S.Command.Border">Tilføj kanter</s:String>
     <s:String x:Key="S.Command.Shadow">Tilføj skygge</s:String>
@@ -1374,7 +1374,7 @@
     <s:String x:Key="S.Shapes.Fill">Fyld</s:String>
 
     <!--Editor • Mouse clicks-->
-    <s:String x:Key="S.MouseClicks">Klik</s:String>
+    <s:String x:Key="S.MouseEvents">Klik</s:String>
     <s:String x:Key="S.MouseClicks.Color.Left">Venstreklik:</s:String>
     <s:String x:Key="S.MouseClicks.Color.Middle">Midterklik:</s:String>
     <s:String x:Key="S.MouseClicks.Color.Right">Højreklik:</s:String>

--- a/ScreenToGif/Resources/Localization/StringResources.de.xaml
+++ b/ScreenToGif/Resources/Localization/StringResources.de.xaml
@@ -123,7 +123,7 @@
     <s:String x:Key="S.Command.KeyStrokes">Tastenanschläge während der Aufnahme hinzufügen</s:String>
     <s:String x:Key="S.Command.FreeDrawing">Freie Zeichnungen erstellen</s:String>
     <s:String x:Key="S.Command.Shapes">Formen hinzufügen</s:String>
-    <s:String x:Key="S.Command.MouseClicks">Mausklicks</s:String>
+    <s:String x:Key="S.Command.MouseEvents">Mausklicks</s:String>
     <s:String x:Key="S.Command.Watermark">Grafik auswählen und als Wasserzeichen hinzufügen</s:String>
     <s:String x:Key="S.Command.Border">Rahmen hinzufügen</s:String>
     <s:String x:Key="S.Command.Shadow">Schatten hinzufügen</s:String>

--- a/ScreenToGif/Resources/Localization/StringResources.el.xaml
+++ b/ScreenToGif/Resources/Localization/StringResources.el.xaml
@@ -103,7 +103,7 @@
     <s:String x:Key="S.Command.KeyStrokes">Εισάγει τα πλήκτρα που πατήθηκαν κατά την εγγραφή</s:String>
     <s:String x:Key="S.Command.FreeDrawing">Σχεδιάστε ελεύθερες φόρμες</s:String>
     <s:String x:Key="S.Command.Shapes">Προσθήκη σχημάτων</s:String>
-    <s:String x:Key="S.Command.MouseClicks">Κλίκ Ποντικιού</s:String>
+    <s:String x:Key="S.Command.MouseEvents">Κλίκ Ποντικιού</s:String>
     <s:String x:Key="S.Command.Watermark">Επιλέξτε μια εικόνα και προσθέστε ως υδατογράφημα</s:String>
     <s:String x:Key="S.Command.Border">Προσθέστε περιγράμματα</s:String>
     <s:String x:Key="S.Command.Shadow">Προσθήκη σκιάς</s:String>
@@ -1221,7 +1221,7 @@
     <s:String x:Key="S.Shapes.Fill">Γέμισμα</s:String>
 
     <!--Editor • Mouse clicks-->
-    <s:String x:Key="S.MouseClicks">Κλικ ποντικιού</s:String>
+    <s:String x:Key="S.MouseEvents">Κλικ ποντικιού</s:String>
     <s:String x:Key="S.MouseClicks.Warning.None">Δεν υπάρχουν εντοπισμένα κλικ ποντικιού στο έργο σας.</s:String>
     
     <!--Editor • Watermark-->

--- a/ScreenToGif/Resources/Localization/StringResources.en.xaml
+++ b/ScreenToGif/Resources/Localization/StringResources.en.xaml
@@ -123,7 +123,7 @@
     <s:String x:Key="S.Command.KeyStrokes">Inserts keys pressed during the recording</s:String>
     <s:String x:Key="S.Command.FreeDrawing">Draw free forms</s:String>
     <s:String x:Key="S.Command.Shapes">Add shapes</s:String>
-    <s:String x:Key="S.Command.MouseEvents">Mouse clicks</s:String>
+    <s:String x:Key="S.Command.MouseEvents">Mouse events</s:String>
     <s:String x:Key="S.Command.Watermark">Select an image and add as watermark</s:String>
     <s:String x:Key="S.Command.Border">Add borders</s:String>
     <s:String x:Key="S.Command.Shadow">Add drop shadow</s:String>

--- a/ScreenToGif/Resources/Localization/StringResources.en.xaml
+++ b/ScreenToGif/Resources/Localization/StringResources.en.xaml
@@ -123,7 +123,7 @@
     <s:String x:Key="S.Command.KeyStrokes">Inserts keys pressed during the recording</s:String>
     <s:String x:Key="S.Command.FreeDrawing">Draw free forms</s:String>
     <s:String x:Key="S.Command.Shapes">Add shapes</s:String>
-    <s:String x:Key="S.Command.MouseClicks">Mouse clicks</s:String>
+    <s:String x:Key="S.Command.MouseEvents">Mouse clicks</s:String>
     <s:String x:Key="S.Command.Watermark">Select an image and add as watermark</s:String>
     <s:String x:Key="S.Command.Border">Add borders</s:String>
     <s:String x:Key="S.Command.Shadow">Add drop shadow</s:String>

--- a/ScreenToGif/Resources/Localization/StringResources.es-AR.xaml
+++ b/ScreenToGif/Resources/Localization/StringResources.es-AR.xaml
@@ -99,7 +99,7 @@
     <!--<s:String x:Key="S.Command.KeyStrokes">Inserts keys pressed during the recording</s:String>-->
     <!--<s:String x:Key="S.Command.FreeDrawing">Draw free forms</s:String>-->
     <!--<s:String x:Key="S.Command.Shapes">Add shapes</s:String>-->
-    <!--<s:String x:Key="S.Command.MouseClicks">Mouse clicks</s:String>-->
+    <!--<s:String x:Key="S.Command.MouseEvents">Mouse clicks</s:String>-->
     <!--<s:String x:Key="S.Command.Watermark">Select an image and add as watermark</s:String>-->
     <!--<s:String x:Key="S.Command.Border">Add borders</s:String>-->
     <!--<s:String x:Key="S.Command.Shadow">Add drop shadow</s:String>-->
@@ -1145,7 +1145,7 @@
     <!--<s:String x:Key="S.Shapes.Fill">Fill</s:String>-->
 
     <!--Editor • Mouse clicks-->
-    <s:String x:Key="S.MouseClicks">Clics del mouse</s:String>
+    <s:String x:Key="S.MouseEvents">Clics del mouse</s:String>
     <s:String x:Key="S.MouseClicks.Warning.None">No se detectaron clics del mouse en tu proyecto</s:String>
     
     <!--Editor • Watermark-->

--- a/ScreenToGif/Resources/Localization/StringResources.es.xaml
+++ b/ScreenToGif/Resources/Localization/StringResources.es.xaml
@@ -99,7 +99,7 @@
     <s:String x:Key="S.Command.KeyStrokes">Inserta las teclas pulsadas durante la grabación</s:String>
     <s:String x:Key="S.Command.FreeDrawing">Dibujar formas libres</s:String>
     <s:String x:Key="S.Command.Shapes">Añadir formas</s:String>
-    <s:String x:Key="S.Command.MouseClicks">Clicks de raton</s:String>
+    <s:String x:Key="S.Command.MouseEvents">Clicks de raton</s:String>
     <s:String x:Key="S.Command.Watermark">Seleccione una imagen y añada como marca de agua</s:String>
     <s:String x:Key="S.Command.Border">Añadir bordes</s:String>
     <s:String x:Key="S.Command.Shadow">Añadir sombra paralela</s:String>
@@ -1145,7 +1145,7 @@
     <s:String x:Key="S.Shapes.Fill">Relleno</s:String>
 
     <!--Editor • Mouse clicks-->
-    <s:String x:Key="S.MouseClicks">Clicks de Raton</s:String>
+    <s:String x:Key="S.MouseEvents">Clicks de Raton</s:String>
     <s:String x:Key="S.MouseClicks.Warning.None">No se detectan clics con el ratón en el proyecto.</s:String>
     
     <!--Editor • Watermark-->

--- a/ScreenToGif/Resources/Localization/StringResources.fi.xaml
+++ b/ScreenToGif/Resources/Localization/StringResources.fi.xaml
@@ -123,7 +123,7 @@
     <s:String x:Key="S.Command.KeyStrokes">Lisää tallennuksen aikana painetut näppäimet</s:String>
     <s:String x:Key="S.Command.FreeDrawing">Piirrä vapaita kuvioita</s:String>
     <s:String x:Key="S.Command.Shapes">Lisää kuvioita</s:String>
-    <s:String x:Key="S.Command.MouseClicks">Hiiren klikkaukset</s:String>
+    <s:String x:Key="S.Command.MouseEvents">Hiiren klikkaukset</s:String>
     <s:String x:Key="S.Command.Watermark">Valitse kuva ja lisää vesileimana</s:String>
     <s:String x:Key="S.Command.Border">Lisää reunuksia</s:String>
     <s:String x:Key="S.Command.Shadow">Lisää pudotusvarjo</s:String>

--- a/ScreenToGif/Resources/Localization/StringResources.fr.xaml
+++ b/ScreenToGif/Resources/Localization/StringResources.fr.xaml
@@ -123,7 +123,7 @@
     <s:String x:Key="S.Command.KeyStrokes">Insère les touches pressées pendant l'enregistrement</s:String>
     <s:String x:Key="S.Command.FreeDrawing">Dessinez des formulaires gratuits</s:String>
     <s:String x:Key="S.Command.Shapes">Ajouter des formes</s:String>
-    <s:String x:Key="S.Command.MouseEvents">Clics de souris</s:String>
+    <s:String x:Key="S.Command.MouseEvents">Événements de souris</s:String>
     <s:String x:Key="S.Command.Watermark">Sélectionnez une image et ajoutez-la en filigrane</s:String>
     <s:String x:Key="S.Command.Border">Ajouter Bordures</s:String>
     <s:String x:Key="S.Command.Shadow">Ajouter une ombre portée</s:String>

--- a/ScreenToGif/Resources/Localization/StringResources.fr.xaml
+++ b/ScreenToGif/Resources/Localization/StringResources.fr.xaml
@@ -123,7 +123,7 @@
     <s:String x:Key="S.Command.KeyStrokes">Insère les touches pressées pendant l'enregistrement</s:String>
     <s:String x:Key="S.Command.FreeDrawing">Dessinez des formulaires gratuits</s:String>
     <s:String x:Key="S.Command.Shapes">Ajouter des formes</s:String>
-    <s:String x:Key="S.Command.MouseClicks">Clics de souris</s:String>
+    <s:String x:Key="S.Command.MouseEvents">Clics de souris</s:String>
     <s:String x:Key="S.Command.Watermark">Sélectionnez une image et ajoutez-la en filigrane</s:String>
     <s:String x:Key="S.Command.Border">Ajouter Bordures</s:String>
     <s:String x:Key="S.Command.Shadow">Ajouter une ombre portée</s:String>

--- a/ScreenToGif/Resources/Localization/StringResources.he.xaml
+++ b/ScreenToGif/Resources/Localization/StringResources.he.xaml
@@ -122,7 +122,7 @@
     <s:String x:Key="S.Command.KeyStrokes">מוסיף מקשים שנלחצו במהלך ההקלטה</s:String>
     <s:String x:Key="S.Command.FreeDrawing">צייר טפסים בחינם</s:String>
     <s:String x:Key="S.Command.Shapes">הוסף צורות</s:String>
-    <s:String x:Key="S.Command.MouseClicks">לחיצות עכבר</s:String>
+    <s:String x:Key="S.Command.MouseEvents">לחיצות עכבר</s:String>
     <s:String x:Key="S.Command.Watermark">בחר תמונה והוסף כסימן מים</s:String>
     <s:String x:Key="S.Command.Border">הוסף גבולות</s:String>
     <s:String x:Key="S.Command.Shadow">הוסף צל טיפה</s:String>
@@ -1363,7 +1363,7 @@
     <s:String x:Key="S.Shapes.Fill">מילוי</s:String>
 
     <!--Editor • Mouse clicks-->
-    <s:String x:Key="S.MouseClicks">לחיצות עכבר</s:String>
+    <s:String x:Key="S.MouseEvents">לחיצות עכבר</s:String>
     <s:String x:Key="S.MouseClicks.Color.Left">צבע הלחצן השמאלי:</s:String>
     <s:String x:Key="S.MouseClicks.Color.Middle">צבע הכפתור האמצעי:</s:String>
     <s:String x:Key="S.MouseClicks.Color.Right">צבע הלחצן הימני:</s:String>

--- a/ScreenToGif/Resources/Localization/StringResources.hu.xaml
+++ b/ScreenToGif/Resources/Localization/StringResources.hu.xaml
@@ -123,7 +123,7 @@
     <s:String x:Key="S.Command.KeyStrokes">A felvétel közben lenyomott billentyűk beszúrása</s:String>
     <s:String x:Key="S.Command.FreeDrawing">Szabad formák rajzolása</s:String>
     <s:String x:Key="S.Command.Shapes">Alakzatok hozzáadása</s:String>
-    <s:String x:Key="S.Command.MouseClicks">Egérkattintások</s:String>
+    <s:String x:Key="S.Command.MouseEvents">Egérkattintások</s:String>
     <s:String x:Key="S.Command.Watermark">Kép kijelölése és vízjelként való hozzáadása</s:String>
     <s:String x:Key="S.Command.Border">Szegélyek hozzáadása</s:String>
     <s:String x:Key="S.Command.Shadow">Árnyék hozzáadása</s:String>

--- a/ScreenToGif/Resources/Localization/StringResources.it.xaml
+++ b/ScreenToGif/Resources/Localization/StringResources.it.xaml
@@ -123,7 +123,7 @@
     <s:String x:Key="S.Command.KeyStrokes">Inserisci tasti premuti durante la registrazione</s:String>
     <s:String x:Key="S.Command.FreeDrawing">Disegna forme libere</s:String>
     <s:String x:Key="S.Command.Shapes">Aggiungi forme</s:String>
-    <s:String x:Key="S.Command.MouseClicks">Clic del mouse</s:String>
+    <s:String x:Key="S.Command.MouseEvents">Clic del mouse</s:String>
     <s:String x:Key="S.Command.Watermark">Seleziona un'immagine da aggiungere come filigrana</s:String>
     <s:String x:Key="S.Command.Border">Aggiungi bordi</s:String>
     <s:String x:Key="S.Command.Shadow">Aggiungi ombreggiatura</s:String>

--- a/ScreenToGif/Resources/Localization/StringResources.ja.xaml
+++ b/ScreenToGif/Resources/Localization/StringResources.ja.xaml
@@ -118,7 +118,7 @@
     <s:String x:Key="S.Command.KeyStrokes">録画中に押下したキーを表示</s:String>
     <s:String x:Key="S.Command.FreeDrawing">図形を自由に描く</s:String>
     <s:String x:Key="S.Command.Shapes">シェイプを追加</s:String>
-    <s:String x:Key="S.Command.MouseClicks">マウスクリック</s:String>
+    <s:String x:Key="S.Command.MouseEvents">マウスクリック</s:String>
     <s:String x:Key="S.Command.Watermark">選択画像を透かしとして追加</s:String>
     <s:String x:Key="S.Command.Border">帯を追加</s:String>
     <s:String x:Key="S.Command.Shadow">ドロップシャドウ(落し影)を追加</s:String>
@@ -1363,7 +1363,7 @@
     <s:String x:Key="S.Shapes.Fill">塗りつぶし</s:String>
 
     <!--Editor • Mouse clicks-->
-    <s:String x:Key="S.MouseClicks">マウスクリック</s:String>
+    <s:String x:Key="S.MouseEvents">マウスクリック</s:String>
     <s:String x:Key="S.MouseClicks.Color.Left">左クリックの色：</s:String>
     <s:String x:Key="S.MouseClicks.Color.Middle">中クリックの色：</s:String>
     <s:String x:Key="S.MouseClicks.Color.Right">右クリックの色：</s:String>

--- a/ScreenToGif/Resources/Localization/StringResources.ko.xaml
+++ b/ScreenToGif/Resources/Localization/StringResources.ko.xaml
@@ -103,7 +103,7 @@
     <s:String x:Key="S.Command.KeyStrokes">녹화 중 입력한 키 삽입하거나 편집하기</s:String>
     <s:String x:Key="S.Command.FreeDrawing">그림 그리기</s:String>
     <s:String x:Key="S.Command.Shapes">도형 추가하기</s:String>
-    <s:String x:Key="S.Command.MouseClicks">마우스 클릭</s:String>
+    <s:String x:Key="S.Command.MouseEvents">마우스 클릭</s:String>
     <s:String x:Key="S.Command.Watermark">워터마크 이미지 추가하기</s:String>
     <s:String x:Key="S.Command.Border">경계선 추가하기</s:String>
     <s:String x:Key="S.Command.Shadow">그림자 추가하기</s:String>
@@ -1204,7 +1204,7 @@
     <s:String x:Key="S.Shapes.Fill">채우기</s:String>
 
     <!--Editor • Mouse clicks-->
-    <s:String x:Key="S.MouseClicks">마우스 클릭</s:String>
+    <s:String x:Key="S.MouseEvents">마우스 클릭</s:String>
     <s:String x:Key="S.MouseClicks.Warning.None">프로젝트에 인식된 마우스 클릭이 없습니다.</s:String>
     
     <!--Editor • Watermark-->

--- a/ScreenToGif/Resources/Localization/StringResources.nl.xaml
+++ b/ScreenToGif/Resources/Localization/StringResources.nl.xaml
@@ -123,7 +123,7 @@
     <s:String x:Key="S.Command.KeyStrokes">Voegt toetsen in die tijdens de opname zijn ingedrukt</s:String>
     <s:String x:Key="S.Command.FreeDrawing">Teken vrije vormen</s:String>
     <s:String x:Key="S.Command.Shapes">Vormen toevoegen</s:String>
-    <s:String x:Key="S.Command.MouseClicks">Muisklikken</s:String>
+    <s:String x:Key="S.Command.MouseEvents">Muisklikken</s:String>
     <s:String x:Key="S.Command.Watermark">Selecteer een afbeelding en voeg toe als watermerk</s:String>
     <s:String x:Key="S.Command.Border">Randen toevoegen</s:String>
     <s:String x:Key="S.Command.Shadow">Slagschaduw toevoegen</s:String>

--- a/ScreenToGif/Resources/Localization/StringResources.pl.xaml
+++ b/ScreenToGif/Resources/Localization/StringResources.pl.xaml
@@ -123,7 +123,7 @@
     <!--<s:String x:Key="S.Command.KeyStrokes">Inserts keys pressed during the recording</s:String>-->
     <!--<s:String x:Key="S.Command.FreeDrawing">Draw free forms</s:String>-->
     <s:String x:Key="S.Command.Shapes">Dodaj kształt</s:String>
-    <s:String x:Key="S.Command.MouseClicks">Kliknięcia myszy</s:String>
+    <s:String x:Key="S.Command.MouseEvents">Kliknięcia myszy</s:String>
     <s:String x:Key="S.Command.Watermark">Wybierz obraz i dodaj jako znak wodny</s:String>
     <s:String x:Key="S.Command.Border">Dodaj obramowanie</s:String>
     <s:String x:Key="S.Command.Shadow">Dodaj cień</s:String>

--- a/ScreenToGif/Resources/Localization/StringResources.pt-PT.xaml
+++ b/ScreenToGif/Resources/Localization/StringResources.pt-PT.xaml
@@ -99,7 +99,7 @@
     <!--<s:String x:Key="S.Command.KeyStrokes">Inserts keys pressed during the recording</s:String>-->
     <!--<s:String x:Key="S.Command.FreeDrawing">Draw free forms</s:String>-->
     <!--<s:String x:Key="S.Command.Shapes">Add shapes</s:String>-->
-    <!--<s:String x:Key="S.Command.MouseClicks">Mouse clicks</s:String>-->
+    <!--<s:String x:Key="S.Command.MouseEvents">Mouse clicks</s:String>-->
     <!--<s:String x:Key="S.Command.Watermark">Select an image and add as watermark</s:String>-->
     <!--<s:String x:Key="S.Command.Border">Add borders</s:String>-->
     <!--<s:String x:Key="S.Command.Shadow">Add drop shadow</s:String>-->
@@ -1145,7 +1145,7 @@
     <!--<s:String x:Key="S.Shapes.Fill">Fill</s:String>-->
 
     <!--Editor • Mouse clicks-->
-    <!--<s:String x:Key="S.MouseClicks">Mouse Clicks</s:String>-->
+    <!--<s:String x:Key="S.MouseEvents">Mouse Clicks</s:String>-->
     <!--<s:String x:Key="S.MouseClicks.Warning.None">There's no detected mouse clicks on your project.</s:String>-->
     
     <!--Editor • Watermark-->

--- a/ScreenToGif/Resources/Localization/StringResources.pt.xaml
+++ b/ScreenToGif/Resources/Localization/StringResources.pt.xaml
@@ -123,7 +123,7 @@
     <s:String x:Key="S.Command.KeyStrokes">Pressionamentos de tecla: inserir teclas pressionadas durante a gravação</s:String>
     <s:String x:Key="S.Command.FreeDrawing">Desenhe livremente</s:String>
     <s:String x:Key="S.Command.Shapes">Adicione formas geométricas</s:String>
-    <s:String x:Key="S.Command.MouseClicks">Cliques do mouse</s:String>
+    <s:String x:Key="S.Command.MouseEvents">Cliques do mouse</s:String>
     <s:String x:Key="S.Command.Watermark">Selecione uma imagem e adicione como marca d'água</s:String>
     <s:String x:Key="S.Command.Border">Adicionar bordas</s:String>
     <s:String x:Key="S.Command.Shadow">Adicionar sombra</s:String>
@@ -1382,7 +1382,7 @@
     <s:String x:Key="S.Shapes.Fill">Preenchimento</s:String>
 
     <!--Editor • Mouse clicks-->
-    <s:String x:Key="S.MouseClicks">Cliques do Mouse</s:String>
+    <s:String x:Key="S.MouseEvents">Cliques do Mouse</s:String>
     <s:String x:Key="S.MouseClicks.Color.Left">Cor do botão esquerdo:</s:String>
     <s:String x:Key="S.MouseClicks.Color.Middle">Cor do botão do meio:</s:String>
     <s:String x:Key="S.MouseClicks.Color.Right">Cor do botão direito:</s:String>

--- a/ScreenToGif/Resources/Localization/StringResources.ru.xaml
+++ b/ScreenToGif/Resources/Localization/StringResources.ru.xaml
@@ -776,7 +776,7 @@
     <s:String x:Key="S.Preset.Autosave">Автосохранение</s:String>
     <s:String x:Key="S.Preset.Autosave.Info">Изменения в этом пресете сохраняются автоматически.</s:String>
     <s:String x:Key="S.Preset.Default.Title">По умолчанию ({0})</s:String>
-    <s:String x:Key="S.Preset.Default.Description">Пресет по умолчанию для кодеровщика.</s:String>
+    <s:String x:Key="S.Preset.Default.Description">Пресет по умолчанию для кодировщика.</s:String>
     <s:String x:Key="S.Preset.Twitter.Title">Для Twitter ({0})</s:String>
     <s:String x:Key="S.Preset.Twitter.Description">Соблюдает ограничения Twitter (кроме размера и разрешения).</s:String>
     <s:String x:Key="S.Preset.Hevc.Title">HEVC ({0})</s:String>
@@ -1253,7 +1253,7 @@
     <s:String x:Key="S.Resize.Difference">Разница</s:String>
     <s:String x:Key="S.Resize.Dpi">DPI</s:String>
     <s:String x:Key="S.Resize.Options">Настройки</s:String>
-    <s:String x:Key="S.Resize.Pixels">Пмксели (px)</s:String>
+    <s:String x:Key="S.Resize.Pixels">Пиксели (px)</s:String>
     <s:String x:Key="S.Resize.Percent">Проценты (%)</s:String>
     <s:String x:Key="S.Resize.Dpi2">DPI:</s:String>
     <s:String x:Key="S.Resize.KeepAspect">Сохранить пропорции.</s:String>

--- a/ScreenToGif/Resources/Localization/StringResources.ru.xaml
+++ b/ScreenToGif/Resources/Localization/StringResources.ru.xaml
@@ -123,7 +123,7 @@
     <s:String x:Key="S.Command.KeyStrokes">Нажатие клавиш: вставляет клавиши, нажатые во время записи</s:String>
     <s:String x:Key="S.Command.FreeDrawing">Рисование свободных форм</s:String>
     <s:String x:Key="S.Command.Shapes">Добавить фигуры</s:String>
-    <s:String x:Key="S.Command.MouseClicks">Щелчки мыши</s:String>
+    <s:String x:Key="S.Command.MouseEvents">Щелчки мыши</s:String>
     <s:String x:Key="S.Command.Watermark">Выбрать и добавить изображение как водяной знак</s:String>
     <s:String x:Key="S.Command.Border">Добавить границы</s:String>
     <s:String x:Key="S.Command.Shadow">Добавить тень</s:String>

--- a/ScreenToGif/Resources/Localization/StringResources.sv.xaml
+++ b/ScreenToGif/Resources/Localization/StringResources.sv.xaml
@@ -99,7 +99,7 @@
     <s:String x:Key="S.Command.KeyStrokes">Tangenttryckningar: infogar knapptryckningar i inspelningen</s:String>
     <s:String x:Key="S.Command.FreeDrawing">Rita fritt</s:String>
     <s:String x:Key="S.Command.Shapes">Lägg till former</s:String>
-    <s:String x:Key="S.Command.MouseClicks">Musklick</s:String>
+    <s:String x:Key="S.Command.MouseEvents">Musklick</s:String>
     <s:String x:Key="S.Command.Watermark">Välj en bild och lägg till den som vattenstämpel</s:String>
     <s:String x:Key="S.Command.Border">Lägg till kant</s:String>
     <s:String x:Key="S.Command.Shadow">Lägg till skugga</s:String>
@@ -1145,7 +1145,7 @@
     <s:String x:Key="S.Shapes.Fill">Fyll</s:String>
 
     <!--Editor • Mouse clicks-->
-    <s:String x:Key="S.MouseClicks">Musklick</s:String>
+    <s:String x:Key="S.MouseEvents">Musklick</s:String>
     <s:String x:Key="S.MouseClicks.Warning.None">Det finns inga upptäckta musklick i ditt projekt.</s:String>
     
     <!--Editor • Watermark-->

--- a/ScreenToGif/Resources/Localization/StringResources.sw.xaml
+++ b/ScreenToGif/Resources/Localization/StringResources.sw.xaml
@@ -99,7 +99,7 @@
     <s:String x:Key="S.Command.KeyStrokes">Huingiza vitufe vilivyobonyezwa wakati wa kurekodi</s:String>
     <s:String x:Key="S.Command.FreeDrawing">Chora umbizo huru</s:String>
     <s:String x:Key="S.Command.Shapes">Ongeza maumbo</s:String>
-    <s:String x:Key="S.Command.MouseClicks">Mbofyo wa kipanya:</s:String>
+    <s:String x:Key="S.Command.MouseEvents">Mbofyo wa kipanya:</s:String>
     <s:String x:Key="S.Command.Watermark">Teua picha na ongeza kama taswira fifi</s:String>
     <s:String x:Key="S.Command.Border">Ongeza boda</s:String>
     <s:String x:Key="S.Command.Shadow">Ongeza kivuli kunjuzi</s:String>
@@ -1145,7 +1145,7 @@
     <s:String x:Key="S.Shapes.Fill">Jaza</s:String>
 
     <!--Editor • Mouse clicks-->
-    <s:String x:Key="S.MouseClicks">Mibofyo ya kipanya</s:String>
+    <s:String x:Key="S.MouseEvents">Mibofyo ya kipanya</s:String>
     <s:String x:Key="S.MouseClicks.Warning.None">Hakuna mbofyo wa kipanya uliogunduliwa kwa mradi wako.</s:String>
     
     <!--Editor • Watermark-->

--- a/ScreenToGif/Resources/Localization/StringResources.tr.xaml
+++ b/ScreenToGif/Resources/Localization/StringResources.tr.xaml
@@ -99,7 +99,7 @@
     <s:String x:Key="S.Command.KeyStrokes">Kayıtta basılan tuşları ekle</s:String>
     <s:String x:Key="S.Command.FreeDrawing">Serbest şekiller çiz</s:String>
     <s:String x:Key="S.Command.Shapes">Şekil ekle</s:String>
-    <s:String x:Key="S.Command.MouseClicks">Fare tıklamaları</s:String>
+    <s:String x:Key="S.Command.MouseEvents">Fare tıklamaları</s:String>
     <s:String x:Key="S.Command.Watermark">Bir resmi filigran olarak ekleyin</s:String>
     <s:String x:Key="S.Command.Border">Çerçeve ekle</s:String>
     <s:String x:Key="S.Command.Shadow">Gölge ekle</s:String>
@@ -1145,7 +1145,7 @@
     <s:String x:Key="S.Shapes.Fill">Doldur</s:String>
 
     <!--Editor • Mouse clicks-->
-    <s:String x:Key="S.MouseClicks">Fare Tıklamaları</s:String>
+    <s:String x:Key="S.MouseEvents">Fare Tıklamaları</s:String>
     <s:String x:Key="S.MouseClicks.Warning.None">Projenizde algılanan fare tıklaması yok.</s:String>
     
     <!--Editor • Watermark-->

--- a/ScreenToGif/Resources/Localization/StringResources.uk.xaml
+++ b/ScreenToGif/Resources/Localization/StringResources.uk.xaml
@@ -99,7 +99,7 @@
     <!--<s:String x:Key="S.Command.KeyStrokes">Inserts keys pressed during the recording</s:String>-->
     <!--<s:String x:Key="S.Command.FreeDrawing">Draw free forms</s:String>-->
     <!--<s:String x:Key="S.Command.Shapes">Add shapes</s:String>-->
-    <!--<s:String x:Key="S.Command.MouseClicks">Mouse clicks</s:String>-->
+    <!--<s:String x:Key="S.Command.MouseEvents">Mouse clicks</s:String>-->
     <!--<s:String x:Key="S.Command.Watermark">Select an image and add as watermark</s:String>-->
     <!--<s:String x:Key="S.Command.Border">Add borders</s:String>-->
     <!--<s:String x:Key="S.Command.Shadow">Add drop shadow</s:String>-->
@@ -1145,7 +1145,7 @@
     <!--<s:String x:Key="S.Shapes.Fill">Fill</s:String>-->
 
     <!--Editor • Mouse clicks-->
-    <!--<s:String x:Key="S.MouseClicks">Mouse Clicks</s:String>-->
+    <!--<s:String x:Key="S.MouseEvents">Mouse Clicks</s:String>-->
     <!--<s:String x:Key="S.MouseClicks.Warning.None">There's no detected mouse clicks on your project.</s:String>-->
     
     <!--Editor • Watermark-->

--- a/ScreenToGif/Resources/Localization/StringResources.vi.xaml
+++ b/ScreenToGif/Resources/Localization/StringResources.vi.xaml
@@ -99,7 +99,7 @@
     <!--<s:String x:Key="S.Command.KeyStrokes">Inserts keys pressed during the recording</s:String>-->
     <!--<s:String x:Key="S.Command.FreeDrawing">Draw free forms</s:String>-->
     <!--<s:String x:Key="S.Command.Shapes">Add shapes</s:String>-->
-    <!--<s:String x:Key="S.Command.MouseClicks">Mouse clicks</s:String>-->
+    <!--<s:String x:Key="S.Command.MouseEvents">Mouse clicks</s:String>-->
     <!--<s:String x:Key="S.Command.Watermark">Select an image and add as watermark</s:String>-->
     <!--<s:String x:Key="S.Command.Border">Add borders</s:String>-->
     <!--<s:String x:Key="S.Command.Shadow">Add drop shadow</s:String>-->
@@ -1145,7 +1145,7 @@
     <s:String x:Key="S.Shapes.Fill">Làm đầy</s:String>
 
     <!--Editor • Mouse clicks-->
-    <s:String x:Key="S.MouseClicks">Các click chuột</s:String>
+    <s:String x:Key="S.MouseEvents">Các click chuột</s:String>
     <s:String x:Key="S.MouseClicks.Warning.None">Không có phát hiện click chuột trong dự án của bạn.</s:String>
     
     <!--Editor • Watermark-->

--- a/ScreenToGif/Resources/Localization/StringResources.zh-Hant.xaml
+++ b/ScreenToGif/Resources/Localization/StringResources.zh-Hant.xaml
@@ -122,7 +122,7 @@
     <s:String x:Key="S.Command.KeyStrokes">插入在錄製過程中按鍵的文字展示</s:String>
     <s:String x:Key="S.Command.FreeDrawing">自由繪製</s:String>
     <s:String x:Key="S.Command.Shapes">加入形狀</s:String>
-    <s:String x:Key="S.Command.MouseClicks">滑鼠點擊</s:String>
+    <s:String x:Key="S.Command.MouseEvents">滑鼠點擊</s:String>
     <s:String x:Key="S.Command.Watermark">選擇圖片並加入為浮水印</s:String>
     <s:String x:Key="S.Command.Border">新增邊框</s:String>
     <s:String x:Key="S.Command.Shadow">加入陰影</s:String>
@@ -1361,7 +1361,7 @@
     <s:String x:Key="S.Shapes.Fill">填充</s:String>
 
     <!--Editor • Mouse clicks-->
-    <s:String x:Key="S.MouseClicks">滑鼠點擊</s:String>
+    <s:String x:Key="S.MouseEvents">滑鼠點擊</s:String>
     <s:String x:Key="S.MouseClicks.Color.Left">左鍵顏色：</s:String>
     <s:String x:Key="S.MouseClicks.Color.Middle">中鍵顏色：</s:String>
     <s:String x:Key="S.MouseClicks.Color.Right">右鍵顏色：</s:String>

--- a/ScreenToGif/Resources/Localization/StringResources.zh.xaml
+++ b/ScreenToGif/Resources/Localization/StringResources.zh.xaml
@@ -123,7 +123,7 @@
     <s:String x:Key="S.Command.KeyStrokes">按键：插入在录制过程中按下的按键</s:String>
     <s:String x:Key="S.Command.FreeDrawing">绘制自由形式</s:String>
     <s:String x:Key="S.Command.Shapes">添加形状</s:String>
-    <s:String x:Key="S.Command.MouseClicks">鼠标点击</s:String>
+    <s:String x:Key="S.Command.MouseEvents">鼠标点击</s:String>
     <s:String x:Key="S.Command.Watermark">选择图像并添加为水印</s:String>
     <s:String x:Key="S.Command.Border">添加边框</s:String>
     <s:String x:Key="S.Command.Shadow">添加阴影</s:String>


### PR DESCRIPTION
PR #1046 changed the "Mouse Clicks" panel/button to "Mouse Events" instead, since mouse-related events could now be visible without clicking; a sensible change. However, the PR missed a few references to `*.MouseClicks` in the code, resulting in the tooltip for the button not showing up correctly.

This PR switches all references to `*.MouseClicks` to their respective `*.MouseEvents` versions in all language `.xaml` files in `/Resources/Localization`. Additionally, it updates the values for the text itself from "Mouse clicks" to "Mouse events" within the tooltip for English and French (because those are the two languages that I know).

It may be a good idea to let those on the localization teams know that "Mouse clicks" should be changed to "Mouse events" for consistency. I also noticed several references in the other files to `S.MouseClicks.Warning.None`&mdash;this string no longer appears, since it's not really possible for a recording not to have any generic "mouse events" like it is for clicks. It can probably be removed from the language files. I don't think either of these last two points are particularly urgent, though.

This PR fixes #1200.

## Screenshots

### Before

![Tooltip before, EN](https://github.com/NickeManarin/ScreenToGif/assets/43387454/c3156876-3500-41df-b909-c6bcb1983418)

![Tooltip before, DE](https://github.com/NickeManarin/ScreenToGif/assets/43387454/86093846-c609-4c0b-846c-199930b4c62a)

### After

![Tooltip after, EN](https://github.com/NickeManarin/ScreenToGif/assets/43387454/6b93ca22-6e60-4f6d-83bb-389fd7d93dd9)

![Tooltip after, DE](https://github.com/NickeManarin/ScreenToGif/assets/43387454/f43fe29c-cfd8-4bf7-850a-083c5677f5df)

---

Cheers,  
-- Matt