### PR TITLE
 Add ability to set background color for Free Text in the Editor

### DIFF
--- a/ScreenToGif.Util/Settings/UserSettings.cs
+++ b/ScreenToGif.Util/Settings/UserSettings.cs
@@ -2039,6 +2039,12 @@ public class UserSettings : INotifyPropertyChanged
         set => SetValue(value);
     }
 
+    public Color FreeTextBackgroundColor
+    {
+        get => (Color)GetValue();
+        set => SetValue(value);
+    }
+
     public TextAlignment FreeTextTextAlignment
     {
         get => (TextAlignment)GetValue();

--- a/ScreenToGif/Resources/Localization/StringResources.ar.xaml
+++ b/ScreenToGif/Resources/Localization/StringResources.ar.xaml
@@ -1093,6 +1093,7 @@
     <s:String x:Key="S.Caption.Weight">الوزن:</s:String>
     <s:String x:Key="S.Caption.Size">الحجم:</s:String>
     <s:String x:Key="S.Caption.Color">اللون:</s:String>
+    <s:String x:Key="S.Caption.BackgroundColor">لون الخلفية:</s:String>
     <s:String x:Key="S.Caption.Outline">خط خارجي</s:String>
     <s:String x:Key="S.Caption.Thickness">سمك:</s:String>
     <s:String x:Key="S.Caption.Layout">تخطيط</s:String>

--- a/ScreenToGif/Resources/Localization/StringResources.cs.xaml
+++ b/ScreenToGif/Resources/Localization/StringResources.cs.xaml
@@ -1093,6 +1093,7 @@
     <s:String x:Key="S.Caption.Weight">Tloušťka:</s:String>
     <s:String x:Key="S.Caption.Size">Velikost:</s:String>
     <s:String x:Key="S.Caption.Color">Barva:</s:String>
+    <s:String x:Key="S.Caption.BackgroundColor">Barva pozadí:</s:String>
     <s:String x:Key="S.Caption.Outline">Obrys</s:String>
     <s:String x:Key="S.Caption.Thickness">Tloušťka:</s:String>
     <s:String x:Key="S.Caption.Layout">Uspořádání</s:String>

--- a/ScreenToGif/Resources/Localization/StringResources.da.xaml
+++ b/ScreenToGif/Resources/Localization/StringResources.da.xaml
@@ -1317,6 +1317,7 @@
     <s:String x:Key="S.Caption.Weight">Vægt:</s:String>
     <s:String x:Key="S.Caption.Size">Str:</s:String>
     <s:String x:Key="S.Caption.Color">Farve:</s:String>
+    <s:String x:Key="S.Caption.BackgroundColor">Baggrundsfarve:</s:String>
     <s:String x:Key="S.Caption.Outline">Omkreds</s:String>
     <s:String x:Key="S.Caption.Thickness">Tykkelse:</s:String>
     <s:String x:Key="S.Caption.Layout">Placering</s:String>

--- a/ScreenToGif/Resources/Localization/StringResources.de.xaml
+++ b/ScreenToGif/Resources/Localization/StringResources.de.xaml
@@ -1325,6 +1325,7 @@
     <s:String x:Key="S.Caption.Weight">Breite:</s:String>
     <s:String x:Key="S.Caption.Size">Größe:</s:String>
     <s:String x:Key="S.Caption.Color">Farbe:</s:String>
+    <s:String x:Key="S.Caption.BackgroundColor">Hintergrundfarbe:</s:String>
     <s:String x:Key="S.Caption.Outline">Kontur</s:String>
     <s:String x:Key="S.Caption.Thickness">Breite:</s:String>
     <s:String x:Key="S.Caption.Layout">Position</s:String>

--- a/ScreenToGif/Resources/Localization/StringResources.el.xaml
+++ b/ScreenToGif/Resources/Localization/StringResources.el.xaml
@@ -1165,6 +1165,7 @@
     <s:String x:Key="S.Caption.Weight">Βάρος γραμματοσειράς:</s:String>
     <s:String x:Key="S.Caption.Size">Μέγεθος:</s:String>
     <s:String x:Key="S.Caption.Color">Χρώμα</s:String>
+    <s:String x:Key="S.Caption.BackgroundColor">Χρώμα του φόντου:</s:String>
     <s:String x:Key="S.Caption.Outline">Περίγραμμα</s:String>
     <s:String x:Key="S.Caption.Thickness">Πάχος:</s:String>
     <s:String x:Key="S.Caption.Layout">Διάταξη</s:String>

--- a/ScreenToGif/Resources/Localization/StringResources.en.xaml
+++ b/ScreenToGif/Resources/Localization/StringResources.en.xaml
@@ -1325,6 +1325,7 @@
     <s:String x:Key="S.Caption.Weight">Weight:</s:String>
     <s:String x:Key="S.Caption.Size">Size:</s:String>
     <s:String x:Key="S.Caption.Color">Color:</s:String>
+    <s:String x:Key="S.Caption.BackgroundColor">Background Color:</s:String>
     <s:String x:Key="S.Caption.Outline">Outline</s:String>
     <s:String x:Key="S.Caption.Thickness">Thickness:</s:String>
     <s:String x:Key="S.Caption.Layout">Layout</s:String>

--- a/ScreenToGif/Resources/Localization/StringResources.es-AR.xaml
+++ b/ScreenToGif/Resources/Localization/StringResources.es-AR.xaml
@@ -1093,6 +1093,7 @@
     <s:String x:Key="S.Caption.Weight">Peso:</s:String>
     <s:String x:Key="S.Caption.Size">Tamaño:</s:String>
     <s:String x:Key="S.Caption.Color">Color:</s:String>
+    <s:String x:Key="S.Caption.BackgroundColor">Color de fondo:</s:String>
     <s:String x:Key="S.Caption.Outline">Contorno</s:String>
     <s:String x:Key="S.Caption.Thickness">Grosor:</s:String>
     <s:String x:Key="S.Caption.Layout">Diseño</s:String>

--- a/ScreenToGif/Resources/Localization/StringResources.fi.xaml
+++ b/ScreenToGif/Resources/Localization/StringResources.fi.xaml
@@ -1,4 +1,4 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:s="clr-namespace:System;assembly=mscorlib"
                     xml:space="preserve">
@@ -1325,6 +1325,7 @@
     <s:String x:Key="S.Caption.Weight">Paino:</s:String>
     <s:String x:Key="S.Caption.Size">Koko:</s:String>
     <s:String x:Key="S.Caption.Color">Väri:</s:String>
+    <s:String x:Key="S.Caption.BackgroundColor">Taustaväri:</s:String>
     <s:String x:Key="S.Caption.Outline">Hahmotelma</s:String>
     <s:String x:Key="S.Caption.Thickness">Paksuus:</s:String>
     <s:String x:Key="S.Caption.Layout">Asettelu</s:String>

--- a/ScreenToGif/Resources/Localization/StringResources.fr.xaml
+++ b/ScreenToGif/Resources/Localization/StringResources.fr.xaml
@@ -1,4 +1,4 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:s="clr-namespace:System;assembly=mscorlib"
                     xml:space="preserve">
@@ -1325,6 +1325,7 @@
     <s:String x:Key="S.Caption.Weight">Bordure:</s:String>
     <s:String x:Key="S.Caption.Size">Taille:</s:String>
     <s:String x:Key="S.Caption.Color">Couleur:</s:String>
+    <s:String x:Key="S.Caption.BackgroundColor">Couleur de l'arrière plan:</s:String>
     <s:String x:Key="S.Caption.Outline">Contour</s:String>
     <s:String x:Key="S.Caption.Thickness">Épaisseur:</s:String>
     <s:String x:Key="S.Caption.Layout">Disposition</s:String>

--- a/ScreenToGif/Resources/Localization/StringResources.he.xaml
+++ b/ScreenToGif/Resources/Localization/StringResources.he.xaml
@@ -1,4 +1,4 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:s="clr-namespace:System;assembly=mscorlib"
                     xml:space="preserve">
@@ -1306,6 +1306,7 @@
     <s:String x:Key="S.Caption.Weight">משקל:</s:String>
     <s:String x:Key="S.Caption.Size">גודל:</s:String>
     <s:String x:Key="S.Caption.Color">צבע:</s:String>
+    <s:String x:Key="S.Caption.BackgroundColor">צבע רקע:</s:String>
     <s:String x:Key="S.Caption.Outline">מתאר</s:String>
     <s:String x:Key="S.Caption.Thickness">עובי:</s:String>
     <s:String x:Key="S.Caption.Layout">פריסה</s:String>

--- a/ScreenToGif/Resources/Localization/StringResources.hu.xaml
+++ b/ScreenToGif/Resources/Localization/StringResources.hu.xaml
@@ -1,4 +1,4 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:s="clr-namespace:System;assembly=mscorlib"
                     xml:space="preserve">
@@ -1325,6 +1325,7 @@
     <s:String x:Key="S.Caption.Weight">Vastagság:</s:String>
     <s:String x:Key="S.Caption.Size">Méret:</s:String>
     <s:String x:Key="S.Caption.Color">Szín:</s:String>
+    <s:String x:Key="S.Caption.BackgroundColor">Háttérszín:</s:String>
     <s:String x:Key="S.Caption.Outline">Körvonal</s:String>
     <s:String x:Key="S.Caption.Thickness">Vastagság:</s:String>
     <s:String x:Key="S.Caption.Layout">Elrendezés</s:String>

--- a/ScreenToGif/Resources/Localization/StringResources.it.xaml
+++ b/ScreenToGif/Resources/Localization/StringResources.it.xaml
@@ -1,4 +1,4 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:s="clr-namespace:System;assembly=mscorlib"
                     xml:space="preserve">
@@ -1325,6 +1325,7 @@
     <s:String x:Key="S.Caption.Weight">Peso:</s:String>
     <s:String x:Key="S.Caption.Size">Dimensione:</s:String>
     <s:String x:Key="S.Caption.Color">Colore:</s:String>
+    <s:String x:Key="S.Caption.BackgroundColor">Colore di sfondo:</s:String>
     <s:String x:Key="S.Caption.Outline">Contorno</s:String>
     <s:String x:Key="S.Caption.Thickness">Spessore:</s:String>
     <s:String x:Key="S.Caption.Layout">Disposizione</s:String>

--- a/ScreenToGif/Resources/Localization/StringResources.ja.xaml
+++ b/ScreenToGif/Resources/Localization/StringResources.ja.xaml
@@ -1306,6 +1306,7 @@
     <s:String x:Key="S.Caption.Weight">太さ:</s:String>
     <s:String x:Key="S.Caption.Size">サイズ:</s:String>
     <s:String x:Key="S.Caption.Color">色:</s:String>
+    <s:String x:Key="S.Caption.BackgroundColor">背景色:</s:String>
     <s:String x:Key="S.Caption.Outline">アウトライン</s:String>
     <s:String x:Key="S.Caption.Thickness">太さ(厚さ):</s:String>
     <s:String x:Key="S.Caption.Layout">レイアウト</s:String>

--- a/ScreenToGif/Resources/Localization/StringResources.ko.xaml
+++ b/ScreenToGif/Resources/Localization/StringResources.ko.xaml
@@ -1151,6 +1151,7 @@
     <s:String x:Key="S.Caption.Weight">굵기:</s:String>
     <s:String x:Key="S.Caption.Size">크기:</s:String>
     <s:String x:Key="S.Caption.Color">색상:</s:String>
+    <s:String x:Key="S.Caption.BackgroundColor">배경색:</s:String>
     <s:String x:Key="S.Caption.Outline">외곽선</s:String>
     <s:String x:Key="S.Caption.Thickness">두께:</s:String>
     <s:String x:Key="S.Caption.Layout">위치 설정</s:String>

--- a/ScreenToGif/Resources/Localization/StringResources.nl.xaml
+++ b/ScreenToGif/Resources/Localization/StringResources.nl.xaml
@@ -1325,6 +1325,7 @@
     <s:String x:Key="S.Caption.Weight">Gewicht:</s:String>
     <s:String x:Key="S.Caption.Size">Grootte:</s:String>
     <s:String x:Key="S.Caption.Color">Kleur:</s:String>
+    <s:String x:Key="S.Caption.BackgroundColor">Achtergrond kleur:</s:String>
     <s:String x:Key="S.Caption.Outline">Contour</s:String>
     <s:String x:Key="S.Caption.Thickness">Dikte:</s:String>
     <s:String x:Key="S.Caption.Layout">Opmaak</s:String>

--- a/ScreenToGif/Resources/Localization/StringResources.pl.xaml
+++ b/ScreenToGif/Resources/Localization/StringResources.pl.xaml
@@ -1,4 +1,4 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:s="clr-namespace:System;assembly=mscorlib"
                     xml:space="preserve">
@@ -1325,6 +1325,7 @@
     <s:String x:Key="S.Caption.Weight">Waga:</s:String>
     <s:String x:Key="S.Caption.Size">Rozmiar:</s:String>
     <s:String x:Key="S.Caption.Color">Kolor:</s:String>
+    <s:String x:Key="S.Caption.BackgroundColor">Kolor tła:</s:String>
     <s:String x:Key="S.Caption.Outline">Kontur</s:String>
     <s:String x:Key="S.Caption.Thickness">Grubość:</s:String>
     <s:String x:Key="S.Caption.Layout">Układ</s:String>

--- a/ScreenToGif/Resources/Localization/StringResources.pt-PT.xaml
+++ b/ScreenToGif/Resources/Localization/StringResources.pt-PT.xaml
@@ -1325,6 +1325,7 @@
     <s:String x:Key="S.Caption.Weight">Peso:</s:String>
     <s:String x:Key="S.Caption.Size">Tamanho:</s:String>
     <s:String x:Key="S.Caption.Color">Cor:</s:String>
+    <s:String x:Key="S.Caption.BackgroundColor">Cor de fundo:</s:String>
     <s:String x:Key="S.Caption.Outline">Borda</s:String>
     <s:String x:Key="S.Caption.Thickness">Espessura:</s:String>
     <s:String x:Key="S.Caption.Layout">Posicionamento</s:String>

--- a/ScreenToGif/Resources/Localization/StringResources.pt.xaml
+++ b/ScreenToGif/Resources/Localization/StringResources.pt.xaml
@@ -1325,6 +1325,7 @@
     <s:String x:Key="S.Caption.Weight">Peso:</s:String>
     <s:String x:Key="S.Caption.Size">Tamanho:</s:String>
     <s:String x:Key="S.Caption.Color">Cor:</s:String>
+    <s:String x:Key="S.Caption.BackgroundColor">Cor de fundo:</s:String>
     <s:String x:Key="S.Caption.Outline">Borda</s:String>
     <s:String x:Key="S.Caption.Thickness">Espessura:</s:String>
     <s:String x:Key="S.Caption.Layout">Posicionamento</s:String>

--- a/ScreenToGif/Resources/Localization/StringResources.ru.xaml
+++ b/ScreenToGif/Resources/Localization/StringResources.ru.xaml
@@ -1325,6 +1325,7 @@
     <s:String x:Key="S.Caption.Weight">Начертание:</s:String>
     <s:String x:Key="S.Caption.Size">Размер:</s:String>
     <s:String x:Key="S.Caption.Color">Цвет:</s:String>
+    <s:String x:Key="S.Caption.BackgroundColor">Фоновый цвет:</s:String>
     <s:String x:Key="S.Caption.Outline">Обводка</s:String>
     <s:String x:Key="S.Caption.Thickness">Толщина:</s:String>
     <s:String x:Key="S.Caption.Layout">Макет</s:String>

--- a/ScreenToGif/Resources/Localization/StringResources.sv.xaml
+++ b/ScreenToGif/Resources/Localization/StringResources.sv.xaml
@@ -1093,6 +1093,7 @@
     <s:String x:Key="S.Caption.Weight">Vikt:</s:String>
     <s:String x:Key="S.Caption.Size">Storlek:</s:String>
     <s:String x:Key="S.Caption.Color">Färg:</s:String>
+    <s:String x:Key="S.Caption.BackgroundColor">Bakgrundsfärg:</s:String>
     <s:String x:Key="S.Caption.Outline">Översikt</s:String>
     <s:String x:Key="S.Caption.Thickness">Tjocklek:</s:String>
     <s:String x:Key="S.Caption.Layout">Layout</s:String>

--- a/ScreenToGif/Resources/Localization/StringResources.sw.xaml
+++ b/ScreenToGif/Resources/Localization/StringResources.sw.xaml
@@ -1093,6 +1093,7 @@
     <s:String x:Key="S.Caption.Weight">Uzani:</s:String>
     <s:String x:Key="S.Caption.Size">Ukubwa:</s:String>
     <s:String x:Key="S.Caption.Color">Rangi:</s:String>
+    <s:String x:Key="S.Caption.BackgroundColor">Rangi ya Mandharinyuma:</s:String>
     <s:String x:Key="S.Caption.Outline">Kiolezi</s:String>
     <s:String x:Key="S.Caption.Thickness">Unene:</s:String>
     <s:String x:Key="S.Caption.Layout">Mpangilio</s:String>

--- a/ScreenToGif/Resources/Localization/StringResources.tr.xaml
+++ b/ScreenToGif/Resources/Localization/StringResources.tr.xaml
@@ -1093,6 +1093,7 @@
     <s:String x:Key="S.Caption.Weight">Ağırlık:</s:String>
     <s:String x:Key="S.Caption.Size">Boyut:</s:String>
     <s:String x:Key="S.Caption.Color">Renk:</s:String>
+    <s:String x:Key="S.Caption.BackgroundColor">Arka plan rengi:</s:String>
     <s:String x:Key="S.Caption.Outline">Dış çizgi</s:String>
     <s:String x:Key="S.Caption.Thickness">Kalınlık:</s:String>
     <s:String x:Key="S.Caption.Layout">Düzen</s:String>

--- a/ScreenToGif/Resources/Localization/StringResources.uk.xaml
+++ b/ScreenToGif/Resources/Localization/StringResources.uk.xaml
@@ -1,4 +1,4 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:s="clr-namespace:System;assembly=mscorlib"
                     xml:space="preserve">
@@ -1325,6 +1325,7 @@
     <s:String x:Key="S.Caption.Weight">Товщина:</s:String>
     <s:String x:Key="S.Caption.Size">Розмір:</s:String>
     <s:String x:Key="S.Caption.Color">Колір:</s:String>
+    <s:String x:Key="S.Caption.BackgroundColor">Колір фону:</s:String>
     <s:String x:Key="S.Caption.Outline">Контур</s:String>
     <s:String x:Key="S.Caption.Thickness">Товщина:</s:String>
     <s:String x:Key="S.Caption.Layout">Розташування</s:String>

--- a/ScreenToGif/Resources/Localization/StringResources.vi.xaml
+++ b/ScreenToGif/Resources/Localization/StringResources.vi.xaml
@@ -1093,6 +1093,7 @@
     <s:String x:Key="S.Caption.Weight">Độ đậm nét:</s:String>
     <s:String x:Key="S.Caption.Size">Cỡ chữ:</s:String>
     <s:String x:Key="S.Caption.Color">Màu sắc:</s:String>
+    <s:String x:Key="S.Caption.BackgroundColor">Màu nền:</s:String>
     <s:String x:Key="S.Caption.Outline">Đường bao</s:String>
     <s:String x:Key="S.Caption.Thickness">Chiều dày:</s:String>
     <s:String x:Key="S.Caption.Layout">Bố trí</s:String>

--- a/ScreenToGif/Resources/Localization/StringResources.zh-Hant.xaml
+++ b/ScreenToGif/Resources/Localization/StringResources.zh-Hant.xaml
@@ -1325,6 +1325,7 @@
     <s:String x:Key="S.Caption.Weight">粗細：</s:String>
     <s:String x:Key="S.Caption.Size">大小：</s:String>
     <s:String x:Key="S.Caption.Color">顏色：</s:String>
+    <s:String x:Key="S.Caption.BackgroundColor">背景顏色：</s:String>
     <s:String x:Key="S.Caption.Outline">外框</s:String>
     <s:String x:Key="S.Caption.Thickness">粗細：</s:String>
     <s:String x:Key="S.Caption.Layout">配置</s:String>

--- a/ScreenToGif/Resources/Localization/StringResources.zh.xaml
+++ b/ScreenToGif/Resources/Localization/StringResources.zh.xaml
@@ -1325,6 +1325,7 @@
     <s:String x:Key="S.Caption.Weight">字重：</s:String>
     <s:String x:Key="S.Caption.Size">字号：</s:String>
     <s:String x:Key="S.Caption.Color">颜色：</s:String>
+    <s:String x:Key="S.Caption.BackgroundColor">背景颜色：</s:String>
     <s:String x:Key="S.Caption.Outline">轮廓</s:String>
     <s:String x:Key="S.Caption.Thickness">粗细：</s:String>
     <s:String x:Key="S.Caption.Layout">布局</s:String>

--- a/ScreenToGif/Resources/Settings.xaml
+++ b/ScreenToGif/Resources/Settings.xaml
@@ -291,6 +291,7 @@
     <FontWeight x:Key="FreeTextFontWeight">Normal</FontWeight>
     <s:Double x:Key="FreeTextFontSize">16.0</s:Double>
     <Color x:Key="FreeTextFontColor">#FF000000</Color>
+    <Color x:Key="FreeTextBackgroundColor">#00000000</Color>
     <TextAlignment x:Key="FreeTextTextAlignment">Left</TextAlignment>
     <s:String x:Key="FreeTextTextDecoration">None</s:String>
     <s:Boolean x:Key="IsFreeTextShadowGroupExpanded">True</s:Boolean>

--- a/ScreenToGif/Windows/Editor.xaml
+++ b/ScreenToGif/Windows/Editor.xaml
@@ -1435,7 +1435,8 @@
                                    FontStyle="{Binding ElementName=FreeTextFontStyleComboBox, Path=SelectedValue}"
                                    FontWeight="{Binding ElementName=FreeTextFontWeightComboBox, Path=SelectedValue}"
                                    FontSize="{Binding ElementName=FreeTextFontSizeNumericUpDown, Path=Value}"
-                                   Foreground="{Binding ElementName=FreeTextFontColorBox, Path=SelectedBrush}">
+                                   Foreground="{Binding ElementName=FreeTextFontColorBox, Path=SelectedBrush}"
+                                   Background="{Binding ElementName=FreeTextBackgroundColorBox, Path=SelectedBrush}">
                             <TextBlock.Resources>
                                 <c:DoubleToBool x:Key="DoubleToBool"/>
                                 <DropShadowEffect x:Key="DropShadowEffect" 
@@ -2119,6 +2120,7 @@
                                         <RowDefinition Height="Auto"/>
                                         <RowDefinition Height="Auto"/>
                                         <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="Auto"/>
                                     </Grid.RowDefinitions>
                                     <Grid.ColumnDefinitions>
                                         <ColumnDefinition Width="Auto"/>
@@ -2193,8 +2195,12 @@
                                     <n:ColorBox Grid.Row="4" Grid.Column="1" x:Name="FreeTextFontColorBox" Margin="10,5"
                                                 SelectedColor="{Binding FreeTextFontColor, Source={x:Static t:UserSettings.All}, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
 
-                                    <TextBlock Grid.Row="5" Grid.Column="0" Text="{DynamicResource S.Caption.TextDecoration}" VerticalAlignment="Center" Foreground="{DynamicResource Element.Foreground.Medium}"/>
-                                    <ComboBox Grid.Row="5" Grid.Column="1" x:Name="FreeTextTextDecorationComboBox" Margin="10,5" MinWidth="100"
+                                    <TextBlock Grid.Row="5" Grid.Column="0" Text="{DynamicResource S.Caption.BackgroundColor}" VerticalAlignment="Center" Foreground="{DynamicResource Element.Foreground.Medium}"/>
+                                    <n:ColorBox Grid.Row="5" Grid.Column="1" x:Name="FreeTextBackgroundColorBox" Margin="10,5"
+                                                SelectedColor="{Binding FreeTextBackgroundColor, Source={x:Static t:UserSettings.All}, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+
+                                    <TextBlock Grid.Row="6" Grid.Column="0" Text="{DynamicResource S.Caption.TextDecoration}" VerticalAlignment="Center" Foreground="{DynamicResource Element.Foreground.Medium}"/>
+                                    <ComboBox Grid.Row="6" Grid.Column="1" x:Name="FreeTextTextDecorationComboBox" Margin="10,5" MinWidth="100"
                                               SelectedValuePath="Tag" SelectedValue="{Binding Source={x:Static t:UserSettings.All}, Path=FreeTextTextDecoration, Mode=TwoWay}">
                                         <ComboBox.ItemTemplate>
                                             <DataTemplate>


### PR DESCRIPTION
This closes #399 

I often find the need to annotate elements on the screen, but it's difficult on backgrounds that aren't uniform.
This adds ability to control background property on FreeText textbox.

![image](https://github.com/NickeManarin/ScreenToGif/assets/139702932/3aef8545-5d4f-49cd-a5ae-c74a6737566b)

I didn't know what is the process for translations so I just ran them through Google Translator. For `es-AR` and `pt-PT` I just used Spanish and Portuguese respectively.
