### PR TITLE
[Feature] #1241 Do not automatically DOWNLOAD updates in metered networks

### DIFF
--- a/ScreenToGif.Util/Settings/UserSettings.cs
+++ b/ScreenToGif.Util/Settings/UserSettings.cs
@@ -759,6 +759,12 @@ public class UserSettings : INotifyPropertyChanged
         set => SetValue(value);
     }
 
+    public bool DownloadWithMeteredNetwork
+    {
+        get => (bool)GetValue();
+        set => SetValue(value);
+    }
+
     public bool PortableUpdate
     {
         get => (bool)GetValue();

--- a/ScreenToGif/Resources/Localization/StringResources.en.xaml
+++ b/ScreenToGif/Resources/Localization/StringResources.en.xaml
@@ -261,6 +261,8 @@
     <s:String x:Key="S.Options.App.General.PortableUpdate.Info">(Requires a manual installation by unzipping and replacing the executable)</s:String>
     <s:String x:Key="S.Options.App.General.ForceUpdateAsAdmin">Force the update to run with elevated privileges.</s:String>
     <s:String x:Key="S.Options.App.General.PromptToInstall">Prompt me before the installation starts.</s:String>
+    <s:String x:Key="S.Options.App.General.DownloadWithMeteredNetwork">Download updates with metered network.</s:String>
+    <s:String x:Key="S.Options.App.General.DownloadWithMeteredNetwork.Info">(Set your connection type in system settings)</s:String>
 
     <!--Options • Recorder-->
     <s:String x:Key="S.Options.Recorder.Interface">Interface</s:String>

--- a/ScreenToGif/Resources/Localization/StringResources.zh.xaml
+++ b/ScreenToGif/Resources/Localization/StringResources.zh.xaml
@@ -261,6 +261,8 @@
     <s:String x:Key="S.Options.App.General.PortableUpdate.Info">（需要通过解压缩和替换可执行文件来进行手动安装）</s:String>
     <s:String x:Key="S.Options.App.General.ForceUpdateAsAdmin">强制更新时提升特权</s:String>
     <s:String x:Key="S.Options.App.General.PromptToInstall">在安装开始之前提示我</s:String>
+    <s:String x:Key="S.Options.App.General.DownloadWithMeteredNetwork">使用按流量计费的连接下载更新</s:String>
+    <s:String x:Key="S.Options.App.General.DownloadWithMeteredNetwork.Info">（在系统设置中设置您的连接类型）</s:String>
 
     <!--Options • Recorder-->
     <s:String x:Key="S.Options.Recorder.Interface">界面</s:String>

--- a/ScreenToGif/Resources/Settings.xaml
+++ b/ScreenToGif/Resources/Settings.xaml
@@ -57,6 +57,7 @@
     <s:Boolean x:Key="DisableHardwareAcceleration">False</s:Boolean>
     <s:Boolean x:Key="CheckForTranslationUpdates">True</s:Boolean>
     <s:Boolean x:Key="CheckForUpdates">True</s:Boolean>
+    <s:Boolean x:Key="DownloadWithMeteredNetwork">True</s:Boolean>
     <s:Boolean x:Key="PortableUpdate">False</s:Boolean>
     <s:Boolean x:Key="ForceUpdateAsAdmin">False</s:Boolean>
     <s:Boolean x:Key="InstallUpdates">True</s:Boolean>

--- a/ScreenToGif/Util/Other.cs
+++ b/ScreenToGif/Util/Other.cs
@@ -14,6 +14,7 @@ using ScreenToGif.Model;
 using ScreenToGif.Native.External;
 using ScreenToGif.Native.Structs;
 using ScreenToGif.Util.Settings;
+using Windows.Networking.Connectivity;
 
 namespace ScreenToGif.Util;
 
@@ -229,6 +230,27 @@ public static class Other
             if (p.CanWrite)
                 p.SetValue(dest, sourceProp.GetValue(source, null), null);
         }
+    }
+
+    public static bool IsMeteredNetwork()
+    {
+        ConnectionProfile internetConnectionProfile = NetworkInformation.GetInternetConnectionProfile();
+
+        if (internetConnectionProfile != null)
+        {
+            NetworkCostType networkCostType = internetConnectionProfile.GetConnectionCost().NetworkCostType;
+
+            if (networkCostType == NetworkCostType.Unrestricted)
+            {
+                return false;
+            }
+            else if (networkCostType == NetworkCostType.Fixed || networkCostType == NetworkCostType.Variable)
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     #region List

--- a/ScreenToGif/ViewModel/ApplicationViewModel.cs
+++ b/ScreenToGif/ViewModel/ApplicationViewModel.cs
@@ -985,7 +985,8 @@ internal class ApplicationViewModel : ApplicationBaseViewModel
                 Global.UpdateAvailable.Version), StatusType.Update, "update", PromptUpdate));
 
             //Download update to be installed when the app closes.
-            if (UserSettings.All.InstallUpdates && Global.UpdateAvailable.HasDownloadLink)
+            if (UserSettings.All.InstallUpdates && Global.UpdateAvailable.HasDownloadLink
+                && (UserSettings.All.DownloadWithMeteredNetwork || !Util.Other.IsMeteredNetwork()))
                 await DownloadUpdate();
 
             return true;

--- a/ScreenToGif/Windows/Options.xaml
+++ b/ScreenToGif/Windows/Options.xaml
@@ -392,6 +392,8 @@
                                     <n:ExtendedCheckBox Text="{DynamicResource S.Options.App.General.UpdateOnClose}" Margin="30,3,5,3" IsChecked="{Binding Path=InstallUpdates, Mode=TwoWay}"/>
                                     <n:ExtendedCheckBox Text="{DynamicResource S.Options.App.General.PromptToInstall}" Margin="45,3,5,3" IsChecked="{Binding Path=PromptToInstall, Mode=TwoWay}"
                                                         Visibility="{Binding InstallUpdates, Converter={StaticResource Bool2Visibility}}"/>
+                                    <n:ExtendedCheckBox x:Name="DownloadWithMeteredNetworkCheckBox" Text="{DynamicResource S.Options.App.General.DownloadWithMeteredNetwork}"
+                                                        Info="{DynamicResource S.Options.App.General.DownloadWithMeteredNetwork.Info}" Margin="30,3,5,3" IsChecked="{Binding Path=DownloadWithMeteredNetwork, Mode=TwoWay}"/>
                                 </StackPanel>
                             </StackPanel>
                         </Expander>
@@ -507,7 +509,7 @@
                                     <n:IntegerUpDown Minimum="10" Maximum="25000" Value="{Binding Path=PlaybackDelayHour, Mode=TwoWay}" MinWidth="80" Visibility="{Binding ElementName=PerHourRadioButton, Path=IsChecked, Mode=OneWay, Converter={StaticResource Bool2Visibility}}"/>
                                     <TextBlock Text="{DynamicResource S.Options.Recorder.Frequency.Playback.Info}" Padding="0" Margin="5,0,0,0" VerticalAlignment="Center" TextWrapping="WrapWithOverflow" Foreground="{DynamicResource Element.Foreground.Gray150}"/>
                                 </WrapPanel>
-                                
+
                                 <WrapPanel Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="7" Margin="0,5,0,0"
                                            Visibility="{Binding ElementName=InteractionRadioButton, Path=IsChecked, Mode=OneWay, Converter={StaticResource Bool2Visibility}, FallbackValue=Collapsed}">
                                     <TextBlock Text="{DynamicResource S.Options.Recorder.Frequency.Trigger}" Foreground="{DynamicResource Element.Foreground.Medium}" Padding="5,0" VerticalAlignment="Center"/>
@@ -523,7 +525,7 @@
                                     <TextBlock Text="{DynamicResource S.Options.Recorder.Frequency.Trigger.Info}" Padding="0" Margin="5,0,0,0" VerticalAlignment="Center"
                                                TextWrapping="WrapWithOverflow" Foreground="{DynamicResource Element.Foreground.Gray150}"/>
                                 </WrapPanel>
-                                
+
                                 <n:ExtendedCheckBox Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="7" Text="{DynamicResource S.Options.Recorder.FixedFramerate}" 
                                                     Info="{DynamicResource S.Options.Recorder.FixedFramerate.Info}" Margin="5,3" VerticalAlignment="Top" IsChecked="{Binding Path=FixedFrameRate, Mode=TwoWay}"
                                                     Visibility="{Binding ElementName=PerSecondRadioButton, Path=IsChecked, Mode=OneWay, Converter={StaticResource Bool2Visibility}, FallbackValue=Collapsed}"/>
@@ -1158,7 +1160,7 @@
 
                             <n:ExtendedListBoxItem Image="{StaticResource Flag.Finland}" Tag="fi" Content="Finnish / Suomi" Author="VeikkoM"
                                                    ContentWidth="25" ContentHeight="25" IsSelected="{Binding LanguageCode, ConverterParameter=fi, Converter={StaticResource TagToSelection}}"/>
-                            
+
                             <n:ExtendedListBoxItem Image="{StaticResource Flag.France}" Tag="fr" Content="French / Français" Author="Largo, Sébastien 'Tr4ncer' Villemain, Adrick"
                                                    ContentWidth="25" ContentHeight="25" IsSelected="{Binding LanguageCode, ConverterParameter=fr, Converter={StaticResource TagToSelection}}"/>
 

--- a/ScreenToGif/Windows/Options.xaml.cs
+++ b/ScreenToGif/Windows/Options.xaml.cs
@@ -104,6 +104,7 @@ public partial class Options : INotification
         UpdatesCheckBox.Visibility = Visibility.Collapsed;
         CheckForUpdatesLabel.Visibility = Visibility.Collapsed;
         StoreTextBlock.Visibility = Visibility.Visible;
+        DownloadWithMeteredNetworkCheckBox.Visibility = Visibility.Collapsed;
 #elif FULL_MULTI_MSIX
         PortableUpdateCheckBox.Visibility = Visibility.Collapsed;
         AdminUpdateCheckBox.Visibility = Visibility.Collapsed;
@@ -763,7 +764,7 @@ public partial class Options : INotification
         var items = App.NotifyIcon.ContextMenu.Items.OfType<ExtendedMenuItem>();
 
         foreach (var item in items)
-            item.Header = LocalizationHelper.Get((string) item.Tag);
+            item.Header = LocalizationHelper.Get((string)item.Tag);
     }
 
     #endregion


### PR DESCRIPTION
Hello @NickeManarin ,
I've tried to implement this feature requested in #1241 , but I changed it a bit. Instead of don't check for updates, I only constrained the automatic download of new version.

The method to check if is in metered networks comes from here:
[stackoverflow](https://stackoverflow.com/a/73316683)

But there brings a problem.
The WinRT API I used was introduced after Windows 10, so I had to change the target OS version to 10.0.17763.0, which will 
likely make the product incompatible with old Windows version.
I'm still trying to find a way to make it version adaptive, any advice would be appreciated.
But for now I still want to create this PR for visibility.

Appreciate your time!