### PR TITLE
Enable `<RollForward>major</RollForward>` for `ScreenToGif.exe`

### DIFF
--- a/ScreenToGif/ScreenToGif.csproj
+++ b/ScreenToGif/ScreenToGif.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net8.0-windows10.0.17763.0</TargetFramework>
+    <RollForward>major</RollForward>
     <OutputType>WinExe</OutputType>
     <ExpressionBlendVersion>12.0.51020.0</ExpressionBlendVersion>
     <IsWebBootstrapper>false</IsWebBootstrapper>


### PR DESCRIPTION
Allow `ScreenToGif.exe` to run when .NET 8 (the version it currently targets) is not installed, but a later major version, e.g. .NET 9, is available.

ref. https://learn.microsoft.com/en-us/dotnet/core/versions/selection#control-roll-forward-behavior

fixes https://github.com/NickeManarin/ScreenToGif/issues/1380