### PR TITLE
Fix #1400: Check if the user-defined cache folder is empty before deleting it

### DIFF
--- a/ScreenToGif/Util/StorageUtils.cs
+++ b/ScreenToGif/Util/StorageUtils.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using ScreenToGif.Util.Settings;
 using ScreenToGif.Windows.Other;
+using System.Linq;
 
 namespace ScreenToGif.Util;
 
@@ -15,8 +16,13 @@ internal static class StorageUtils
         try
         {
             var cache = Other.AdjustPath(UserSettings.All.TemporaryFolderResolved);
-
-            Directory.Delete(cache, true);
+            var path = Path.Combine(UserSettings.All.TemporaryFolderResolved, "ScreenToGif");
+            Directory.Delete(path, true);
+            // The user-defined cache directory may contain user data. It should only be removed if it is empty.
+            if (!Directory.EnumerateFileSystemEntries(cache).Any())
+            {
+                Directory.Delete(cache);
+            }
         }
         catch (Exception e)
         {


### PR DESCRIPTION
Fix #1400.

The self-contained app will extract .dll files to the %temp% folder. As a result, the app will crash when trying to delete them on exit, because these dll files remain locked by the running process and cannot be accessed or deleted.

Additionally, directly deleting the cache folder is unsafe, since users might have configured it to an important location—such as the Documents folder or D:\draft_files—which may contain other valuable temporary documents or files.