### PR TITLE
Adjust the default Quality of the GifskiGifPreset preset to a higher value

### DIFF
--- a/ScreenToGif.ViewModel/ExportPresets/AnimatedImage/Gif/GifskiGifPreset.cs
+++ b/ScreenToGif.ViewModel/ExportPresets/AnimatedImage/Gif/GifskiGifPreset.cs
@@ -40,7 +40,7 @@ public class GifskiGifPreset : GifPreset
             IsDefault = true,
             CreationDate = new DateTime(2021, 02, 20),
 
-            Quality = 1,
+            Quality = 80,
             Fast = false
         },
 


### PR DESCRIPTION
fixes #1422

This PR changes the default `GifskiGifPreset.Quality` to 80 for the `Gifski • Higher quality` preset.
I guess 80 is a reasonable default for high when considering 20 is the default for low (`Gifski • Lower quality`)?