### PR TITLE
Detect framerate(fps) when importing video

### DIFF
--- a/ScreenToGif.ViewModel/VideoSourceViewModel.cs
+++ b/ScreenToGif.ViewModel/VideoSourceViewModel.cs
@@ -451,14 +451,13 @@ public class VideoSourceViewModel : BindableBase, IDisposable
         double fps = 0;
         if (fpsMatch.Success)
         {
-            string fpsValue = fpsMatch.Groups[1].Value;
+            var fpsValue = fpsMatch.Groups[1].Value;
             double.TryParse(fpsValue, CultureInfo.InvariantCulture, out fps);
         }
 
-        if (fps == 0)
-            fps = 15; // use default value instead of throw exception
-
         Framerate = (int)Math.Round(fps);
+        if (Framerate < 1)
+            Framerate = 15; // use default value instead of throw exception
 
         var size = resolutionsFound[0].Value.Split('x');
 

--- a/ScreenToGif.ViewModel/VideoSourceViewModel.cs
+++ b/ScreenToGif.ViewModel/VideoSourceViewModel.cs
@@ -444,6 +444,22 @@ public class VideoSourceViewModel : BindableBase, IDisposable
         if (timingsFound.Count == 0)
             throw new Exception("No video timing found." + log);
 
+        //Tried to find the fps of the video.
+        var fpsRegex = new Regex("(\\d+(?:\\.\\d+)?)\\s*fps", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        var fpsMatch = fpsRegex.Match(linesFound[0].Value);
+
+        double fps = 0;
+        if (fpsMatch.Success)
+        {
+            string fpsValue = fpsMatch.Groups[1].Value;
+            double.TryParse(fpsValue, CultureInfo.InvariantCulture, out fps);
+        }
+
+        if (fps == 0)
+            fps = 15; // use default value instead of throw exception
+
+        Framerate = (int)Math.Round(fps);
+
         var size = resolutionsFound[0].Value.Split('x');
 
         OriginalWidth = Convert.ToInt32(size[isRotated ? 1 : 0]);


### PR DESCRIPTION
Fix #1455, but encountered some issues that have not been solved yet:

- no fps in some `.wmv` files:
<img width="891" height="202" alt="{D8AE5A54-44D3-4060-B355-9E8118EA07B0}" src="https://github.com/user-attachments/assets/c0679119-2111-4949-9f6d-4b127404a942" />


- multi video streams in some `.avif` files:
<img width="1271" height="301" alt="{5EF459D0-25F6-4D0D-AC33-B049D374E7AA}" src="https://github.com/user-attachments/assets/8a37c722-ac9f-49c4-860b-a51fb9ce0c78" />


Attach sample files here:
[ladybug.wmv.zip](https://github.com/user-attachments/files/27105778/ladybug.wmv.zip)
[animated_avif.zip](https://github.com/user-attachments/files/27105910/animated_avif.zip)
