### PR TITLE
Unsubscribe from SystemEvents.DisplaySettingsChanged in dialog windows

### DIFF
--- a/ScreenToGif/Windows/Other/GraphicsConfigurationDialog.xaml.cs
+++ b/ScreenToGif/Windows/Other/GraphicsConfigurationDialog.xaml.cs
@@ -35,6 +35,13 @@ public partial class GraphicsConfigurationDialog
         SystemEvents.DisplaySettingsChanged += SystemEvents_DisplaySettingsChanged;
     }
 
+    protected override void OnClosed(EventArgs e)
+    {
+        SystemEvents.DisplaySettingsChanged -= SystemEvents_DisplaySettingsChanged;
+
+        base.OnClosed(e);
+    }
+
     #region Eventos
 
     private void Window_Loaded(object sender, RoutedEventArgs e)

--- a/ScreenToGif/Windows/Other/Troubleshoot.xaml.cs
+++ b/ScreenToGif/Windows/Other/Troubleshoot.xaml.cs
@@ -27,6 +27,13 @@ public partial class Troubleshoot
         SystemEvents.DisplaySettingsChanged += SystemEvents_DisplaySettingsChanged;
     }
 
+    protected override void OnClosed(EventArgs e)
+    {
+        SystemEvents.DisplaySettingsChanged -= SystemEvents_DisplaySettingsChanged;
+
+        base.OnClosed(e);
+    }
+
     private void Window_Loaded(object sender, RoutedEventArgs e)
     {
         if (Application.Current.Windows.OfType<Window>().Any(a => a.GetType() != typeof(Troubleshoot)))


### PR DESCRIPTION
This fixes a potential memory leak caused by subscribing dialog windows to the static SystemEvents.DisplaySettingsChanged event without unsubscribing.

Because SystemEvents is static, the event delegate can keep closed dialog instances alive for the lifetime of the process.

Affected windows:
- GraphicsConfigurationDialog
- Troubleshoot

The fix unsubscribes in OnClosed.