### PR TITLE
feat(Editor): Allow mousewheel scrolling in frame list

### DIFF
--- a/ScreenToGif/Windows/Editor.xaml
+++ b/ScreenToGif/Windows/Editor.xaml
@@ -4310,6 +4310,7 @@
                   ItemsSource="{Binding Path=DataContext.Frames, ElementName=EditorWindow}" IsEnabled="{Binding Path=IsLoading, ElementName=EditorWindow, Converter={StaticResource InvertedBoolConverter}}"
                   Visibility="{Binding RelativeSource={RelativeSource Self}, Path=HasItems, Converter={StaticResource Bool2Visibility}}"
                   SelectionChanged="FrameListView_SelectionChanged" PreviewKeyDown="FrameListView_PreviewKeyDown"
+                  PreviewMouseWheel="FrameListView_PreviewMouseWheel"
                   SelectedIndex="{Binding CurrentIndex, Mode=OneWayToSource}">
 
             <ListView.Resources>

--- a/ScreenToGif/Windows/Editor.xaml.cs
+++ b/ScreenToGif/Windows/Editor.xaml.cs
@@ -3101,6 +3101,25 @@ namespace ScreenToGif.Windows
             }
         }
 
+        private ScrollViewer _frameListScrollViewer;
+
+        private ScrollViewer GetFrameListScrollViewer()
+            => _frameListScrollViewer ??= VisualHelper.GetVisualChild<ScrollViewer>(FrameListView);
+
+        private void FrameListView_PreviewMouseWheel(object sender, MouseWheelEventArgs e)
+        {
+            var scrollViewer = GetFrameListScrollViewer();
+
+            if (scrollViewer is null)
+                return;
+
+            if (e.Delta > 0)
+                scrollViewer.LineLeft();
+            else
+                scrollViewer.LineRight();
+
+            e.Handled = true;
+        }
         #endregion
 
         private void PreviewLoop(int selectedIndex)


### PR DESCRIPTION
This enables mouse wheel scrolling for the horizontally laid-out frame list.

WPF does not natively translate vertical mouse wheel input into horizontal scrolling, so the `PreviewMouseWheel` event is used to scroll the list horizontally.

The `ScrollViewer` is cached to avoid repeatedly traversing the visual tree.

https://github.com/user-attachments/assets/b2e4d986-cbb7-479c-917b-10c87dd51586

